### PR TITLE
Add pre-trade brief detail view and controlled editing support

### DIFF
--- a/app/api/pre-trade-brief/[id]/route.ts
+++ b/app/api/pre-trade-brief/[id]/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/authOptions";
+import { createClient } from "@/utils/supabase/server";
+import type { ChecklistStateMap, EditablePreTradeBriefStatus } from "@/types/preTradeBrief";
+
+export const dynamic = "force-dynamic";
+
+const EDITABLE_STATUSES: EditablePreTradeBriefStatus[] = [
+  "draft",
+  "ready",
+  "invalidated",
+  "executed",
+  "skipped",
+];
+
+const isChecklistStateMap = (value: unknown): value is ChecklistStateMap => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+
+  return Object.entries(value).every(([k, v]) => {
+    if (!k.trim()) return false;
+    if (!v || typeof v !== "object" || Array.isArray(v)) return false;
+    const state = v as { completed?: unknown; completedAt?: unknown };
+    if (typeof state.completed !== "boolean") return false;
+    if (state.completedAt !== undefined && typeof state.completedAt !== "string") return false;
+    return true;
+  });
+};
+
+export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = createClient();
+
+    const { data, error } = await supabase
+      .from("pre_trade_briefs")
+      .select(`
+        id,
+        user_id,
+        forex_pair_id,
+        pair_symbol_snapshot,
+        timeframe,
+        market_session,
+        directional_bias_input,
+        setup_notes,
+        planned_entry,
+        planned_stop_loss,
+        planned_take_profit,
+        risk_reward_ratio,
+        ai_summary,
+        ai_bias,
+        ai_confluence,
+        ai_risks,
+        ai_invalidators,
+        ai_checklist,
+        raw_ai_response,
+        status,
+        trader_notes,
+        checklist_state,
+        last_reviewed_at,
+        created_at,
+        updated_at
+      `)
+      .eq("id", params.id)
+      .eq("user_id", session.user.id)
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ error: "Brief not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("GET /api/pre-trade-brief/[id] failed:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+
+    const updatePayload: {
+      status?: EditablePreTradeBriefStatus;
+      trader_notes?: string | null;
+      checklist_state?: ChecklistStateMap | null;
+      last_reviewed_at?: string | null;
+    } = {};
+
+    if (body.status !== undefined) {
+      const status = String(body.status || "").trim().toLowerCase() as EditablePreTradeBriefStatus;
+      if (!EDITABLE_STATUSES.includes(status)) {
+        return NextResponse.json({ error: "Invalid status value" }, { status: 400 });
+      }
+      updatePayload.status = status;
+    }
+
+    if (body.trader_notes !== undefined) {
+      if (body.trader_notes === null || body.trader_notes === "") {
+        updatePayload.trader_notes = null;
+      } else {
+        updatePayload.trader_notes = String(body.trader_notes).slice(0, 5000);
+      }
+    }
+
+    if (body.checklist_state !== undefined) {
+      if (body.checklist_state === null) {
+        updatePayload.checklist_state = null;
+      } else if (!isChecklistStateMap(body.checklist_state)) {
+        return NextResponse.json({ error: "Invalid checklist_state payload" }, { status: 400 });
+      } else {
+        updatePayload.checklist_state = body.checklist_state;
+      }
+    }
+
+    if (body.last_reviewed_at !== undefined) {
+      if (body.last_reviewed_at === null || body.last_reviewed_at === "") {
+        updatePayload.last_reviewed_at = null;
+      } else {
+        const candidate = new Date(body.last_reviewed_at);
+        if (Number.isNaN(candidate.getTime())) {
+          return NextResponse.json({ error: "Invalid last_reviewed_at value" }, { status: 400 });
+        }
+        updatePayload.last_reviewed_at = candidate.toISOString();
+      }
+    }
+
+    if (Object.keys(updatePayload).length === 0) {
+      return NextResponse.json({ error: "No supported fields provided" }, { status: 400 });
+    }
+
+    const supabase = createClient();
+
+    const { data, error } = await supabase
+      .from("pre_trade_briefs")
+      .update(updatePayload)
+      .eq("id", params.id)
+      .eq("user_id", session.user.id)
+      .select(`
+        id,
+        pair_symbol_snapshot,
+        timeframe,
+        market_session,
+        directional_bias_input,
+        setup_notes,
+        planned_entry,
+        planned_stop_loss,
+        planned_take_profit,
+        risk_reward_ratio,
+        ai_summary,
+        ai_bias,
+        ai_confluence,
+        ai_risks,
+        ai_invalidators,
+        ai_checklist,
+        status,
+        trader_notes,
+        checklist_state,
+        last_reviewed_at,
+        created_at,
+        updated_at
+      `)
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ error: "Brief not found or update failed" }, { status: 404 });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("PATCH /api/pre-trade-brief/[id] failed:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/pre-trade-brief/route.ts
+++ b/app/api/pre-trade-brief/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/authOptions";
+import { createClient } from "@/utils/supabase/server";
+import { calculateRiskReward, generatePreTradeBrief } from "@/lib/forex/preTradeBriefService";
+import type { DirectionalBias, MarketSession, PreTradeBriefInput } from "@/types/preTradeBrief";
+
+export const dynamic = "force-dynamic";
+
+const VALID_SESSIONS: MarketSession[] = ["ASIA", "LONDON", "NEW_YORK", "OVERLAP"];
+const VALID_BIAS: DirectionalBias[] = ["bullish", "bearish", "neutral"];
+
+const isValidNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const normalizeOptionalNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = createClient();
+
+    const [pairsResult, briefsResult] = await Promise.all([
+      supabase
+        .from("forex_pairs")
+        .select("id, symbol, base_currency, quote_currency, category")
+        .eq("is_active", true)
+        .order("symbol", { ascending: true }),
+      supabase
+        .from("pre_trade_briefs")
+        .select("id, pair_symbol_snapshot, timeframe, market_session, directional_bias_input, status, created_at")
+        .eq("user_id", session.user.id)
+        .order("created_at", { ascending: false })
+        .limit(10),
+    ]);
+
+    if (pairsResult.error) {
+      return NextResponse.json({ error: pairsResult.error.message }, { status: 500 });
+    }
+
+    if (briefsResult.error) {
+      return NextResponse.json({ error: briefsResult.error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      pairs: pairsResult.data || [],
+      briefs: briefsResult.data || [],
+    });
+  } catch (error) {
+    console.error("GET pre-trade-brief failed:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const pairSymbol = String(body.pairSymbol || "").trim().toUpperCase();
+    const timeframe = String(body.timeframe || "").trim().toUpperCase();
+    const marketSession = String(body.marketSession || "").trim().toUpperCase() as MarketSession;
+    const directionalBiasInput = String(body.directionalBiasInput || "").trim().toLowerCase() as DirectionalBias;
+    const setupNotes = body.setupNotes ? String(body.setupNotes).trim() : "";
+
+    const plannedEntry = normalizeOptionalNumber(body.plannedEntry);
+    const plannedStopLoss = normalizeOptionalNumber(body.plannedStopLoss);
+    const plannedTakeProfit = normalizeOptionalNumber(body.plannedTakeProfit);
+
+    if (!pairSymbol) {
+      return NextResponse.json({ error: "pairSymbol is required" }, { status: 400 });
+    }
+
+    if (!timeframe) {
+      return NextResponse.json({ error: "timeframe is required" }, { status: 400 });
+    }
+
+    if (!VALID_SESSIONS.includes(marketSession)) {
+      return NextResponse.json({ error: "marketSession is invalid" }, { status: 400 });
+    }
+
+    if (!VALID_BIAS.includes(directionalBiasInput)) {
+      return NextResponse.json({ error: "directionalBiasInput is invalid" }, { status: 400 });
+    }
+
+    const hasAnyPrice = [plannedEntry, plannedStopLoss, plannedTakeProfit].some((v) => v !== null);
+    const hasAllPrices = [plannedEntry, plannedStopLoss, plannedTakeProfit].every((v) => isValidNumber(v));
+
+    if (hasAnyPrice && !hasAllPrices) {
+      return NextResponse.json(
+        { error: "plannedEntry, plannedStopLoss, and plannedTakeProfit must all be provided together" },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createClient();
+
+    const { data: pairData, error: pairError } = await supabase
+      .from("forex_pairs")
+      .select("id, symbol")
+      .eq("symbol", pairSymbol)
+      .eq("is_active", true)
+      .single();
+
+    if (pairError || !pairData) {
+      return NextResponse.json({ error: "Selected forex pair is not available" }, { status: 400 });
+    }
+
+    const input: PreTradeBriefInput = {
+      pairSymbol,
+      timeframe,
+      marketSession,
+      directionalBiasInput,
+      setupNotes,
+      plannedEntry,
+      plannedStopLoss,
+      plannedTakeProfit,
+    };
+
+    const aiBrief = await generatePreTradeBrief(input);
+    const riskRewardRatio = calculateRiskReward(plannedEntry, plannedStopLoss, plannedTakeProfit);
+
+    const insertPayload = {
+      user_id: session.user.id,
+      forex_pair_id: pairData.id,
+      pair_symbol_snapshot: pairData.symbol,
+      timeframe,
+      market_session: marketSession,
+      directional_bias_input: directionalBiasInput,
+      setup_notes: setupNotes || null,
+      planned_entry: plannedEntry,
+      planned_stop_loss: plannedStopLoss,
+      planned_take_profit: plannedTakeProfit,
+      risk_reward_ratio: riskRewardRatio,
+      ai_summary: aiBrief.summary,
+      ai_bias: aiBrief.bias,
+      ai_confluence: aiBrief.confluence,
+      ai_risks: aiBrief.risks,
+      ai_invalidators: aiBrief.invalidationSignals,
+      ai_checklist: aiBrief.checklist,
+      raw_ai_response: aiBrief,
+      status: "generated",
+    };
+
+    const { data: created, error: createError } = await supabase
+      .from("pre_trade_briefs")
+      .insert([insertPayload])
+      .select("id, pair_symbol_snapshot, timeframe, market_session, directional_bias_input, risk_reward_ratio, ai_summary, ai_bias, ai_confluence, ai_risks, ai_invalidators, ai_checklist, created_at")
+      .single();
+
+    if (createError) {
+      console.error("Insert pre_trade_briefs failed:", createError);
+      return NextResponse.json({ error: createError.message }, { status: 500 });
+    }
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    console.error("POST pre-trade-brief failed:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/dashboard/pre-trade-brief/page.tsx
+++ b/app/dashboard/pre-trade-brief/page.tsx
@@ -1,0 +1,596 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import LayoutClient from "@/components/LayoutClient";
+import DashboardHeader from "@/components/dashboard/DashboardHeader";
+import { Button } from "@/components/ui/button";
+import type {
+  ChecklistStateMap,
+  EditablePreTradeBriefStatus,
+  PreTradeBriefListItem,
+  PreTradeBriefRecord,
+} from "@/types/preTradeBrief";
+
+type PairOption = {
+  id: string;
+  symbol: string;
+  base_currency: string;
+  quote_currency: string;
+  category: string;
+};
+
+type BriefCreateResult = {
+  id: string;
+  pair_symbol_snapshot: string;
+  timeframe: string;
+  market_session: string;
+  directional_bias_input: string;
+  risk_reward_ratio: number | null;
+  ai_summary: string;
+  ai_bias: string;
+  ai_confluence: string[];
+  ai_risks: string[];
+  ai_invalidators: string[];
+  ai_checklist: string[];
+  created_at: string;
+};
+
+const TIMEFRAMES = ["M5", "M15", "M30", "H1", "H4", "D1"];
+const SESSIONS = ["ASIA", "LONDON", "NEW_YORK", "OVERLAP"];
+const BIASES = ["bullish", "bearish", "neutral"];
+const EDITABLE_STATUSES: EditablePreTradeBriefStatus[] = ["draft", "ready", "invalidated", "executed", "skipped"];
+
+const formatDate = (iso: string) => {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+};
+
+function PreTradeBriefContent() {
+  const { status } = useSession();
+  const router = useRouter();
+
+  const [pairs, setPairs] = useState<PairOption[]>([]);
+  const [recentBriefs, setRecentBriefs] = useState<PreTradeBriefListItem[]>([]);
+
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [result, setResult] = useState<BriefCreateResult | null>(null);
+
+  const [selectedBriefId, setSelectedBriefId] = useState<string | null>(null);
+  const [selectedBrief, setSelectedBrief] = useState<PreTradeBriefRecord | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  const [traderNotesDraft, setTraderNotesDraft] = useState("");
+  const [statusDraft, setStatusDraft] = useState<EditablePreTradeBriefStatus>("draft");
+  const [checklistStateDraft, setChecklistStateDraft] = useState<ChecklistStateMap>({});
+  const [savingDetail, setSavingDetail] = useState(false);
+
+  const [pairSymbol, setPairSymbol] = useState("EURUSD");
+  const [timeframe, setTimeframe] = useState("H1");
+  const [marketSession, setMarketSession] = useState("LONDON");
+  const [directionalBiasInput, setDirectionalBiasInput] = useState("bullish");
+  const [setupNotes, setSetupNotes] = useState("");
+  const [plannedEntry, setPlannedEntry] = useState("");
+  const [plannedStopLoss, setPlannedStopLoss] = useState("");
+  const [plannedTakeProfit, setPlannedTakeProfit] = useState("");
+
+  const canSubmit = useMemo(() => {
+    return Boolean(pairSymbol && timeframe && marketSession && directionalBiasInput);
+  }, [pairSymbol, timeframe, marketSession, directionalBiasInput]);
+
+  const loadData = async () => {
+    setLoading(true);
+    setGlobalError(null);
+
+    try {
+      const response = await fetch("/api/pre-trade-brief", { method: "GET" });
+      if (!response.ok) {
+        const payload = await response.json();
+        throw new Error(payload.error || "Failed to load pre-trade brief data");
+      }
+
+      const payload = await response.json();
+      const nextPairs: PairOption[] = payload.pairs || [];
+      const nextBriefs: PreTradeBriefListItem[] = payload.briefs || [];
+
+      setPairs(nextPairs);
+      setRecentBriefs(nextBriefs);
+
+      if (nextPairs.length && !nextPairs.find((pair) => pair.symbol === pairSymbol)) {
+        setPairSymbol(nextPairs[0].symbol);
+      }
+
+      if (!selectedBriefId && nextBriefs.length) {
+        setSelectedBriefId(nextBriefs[0].id);
+      }
+    } catch (err) {
+      setGlobalError(err instanceof Error ? err.message : "Failed to load pre-trade brief data");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadBriefDetail = async (briefId: string) => {
+    setDetailLoading(true);
+    setDetailError(null);
+
+    try {
+      const response = await fetch(`/api/pre-trade-brief/${briefId}`);
+      if (!response.ok) {
+        const payload = await response.json();
+        throw new Error(payload.error || "Failed to load brief detail");
+      }
+
+      const detail: PreTradeBriefRecord = await response.json();
+      setSelectedBrief(detail);
+      setTraderNotesDraft(detail.trader_notes || "");
+      setStatusDraft(
+        detail.status === "generated" || detail.status === "failed" ? "draft" : detail.status
+      );
+      setChecklistStateDraft(detail.checklist_state || {});
+    } catch (err) {
+      setDetailError(err instanceof Error ? err.message : "Failed to load brief detail");
+      setSelectedBrief(null);
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      void loadData();
+    }
+  }, [status]);
+
+  useEffect(() => {
+    if (status === "authenticated" && selectedBriefId) {
+      void loadBriefDetail(selectedBriefId);
+    }
+  }, [status, selectedBriefId]);
+
+  if (status === "loading" || loading) {
+    return (
+      <div className="min-h-screen w-full bg-white dark:bg-[#0D1117] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  if (status === "unauthenticated") {
+    router.push("/login");
+    return null;
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setGlobalError(null);
+    setSubmitting(true);
+
+    try {
+      const body = {
+        pairSymbol,
+        timeframe,
+        marketSession,
+        directionalBiasInput,
+        setupNotes,
+        plannedEntry,
+        plannedStopLoss,
+        plannedTakeProfit,
+      };
+
+      const response = await fetch("/api/pre-trade-brief", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json();
+        throw new Error(payload.error || "Failed to generate pre-trade brief");
+      }
+
+      const payload: BriefCreateResult = await response.json();
+      setResult(payload);
+      await loadData();
+      setSelectedBriefId(payload.id);
+    } catch (err) {
+      setGlobalError(err instanceof Error ? err.message : "Failed to generate pre-trade brief");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const toggleChecklistItem = (item: string, checked: boolean) => {
+    setChecklistStateDraft((prev) => {
+      const current = prev[item] || { completed: false };
+      return {
+        ...prev,
+        [item]: {
+          completed: checked,
+          completedAt: checked ? new Date().toISOString() : current.completedAt,
+        },
+      };
+    });
+  };
+
+  const handleSaveDetail = async () => {
+    if (!selectedBriefId) return;
+
+    setSavingDetail(true);
+    setDetailError(null);
+
+    try {
+      const response = await fetch(`/api/pre-trade-brief/${selectedBriefId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status: statusDraft,
+          trader_notes: traderNotesDraft,
+          checklist_state: checklistStateDraft,
+          last_reviewed_at: new Date().toISOString(),
+        }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json();
+        throw new Error(payload.error || "Failed to save brief detail");
+      }
+
+      const updated: PreTradeBriefRecord = await response.json();
+      setSelectedBrief((prev) => ({ ...(prev || {}), ...updated } as PreTradeBriefRecord));
+
+      setRecentBriefs((prev) =>
+        prev.map((brief) =>
+          brief.id === updated.id
+            ? {
+                ...brief,
+                status: updated.status,
+              }
+            : brief
+        )
+      );
+    } catch (err) {
+      setDetailError(err instanceof Error ? err.message : "Failed to save brief detail");
+    } finally {
+      setSavingDetail(false);
+    }
+  };
+
+  const renderList = (items: string[]) => (
+    <ul className="list-disc pl-5 space-y-1 text-sm text-gray-700 dark:text-gray-300">
+      {items.map((item, idx) => (
+        <li key={`${item}-${idx}`}>{item}</li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <div className="min-h-screen w-full bg-white dark:bg-[#0D1117] transition-colors duration-300">
+      <div className="flex h-screen">
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <DashboardHeader
+            title="Pre-Trade Brief"
+            description="Generate, inspect, and update Forex planning briefs"
+            showBackButton
+          />
+
+          <div className="flex-1 overflow-auto p-6">
+            <div className="grid gap-6 lg:grid-cols-2">
+              <section className="bg-white dark:bg-[#161B22] border border-gray-200 dark:border-gray-800 rounded-xl p-5">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Create Brief</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                  Decision-support only. AI output is advisory and never guaranteed.
+                </p>
+
+                <form className="space-y-4" onSubmit={handleSubmit}>
+                  <div>
+                    <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Forex Pair</label>
+                    <select
+                      value={pairSymbol}
+                      onChange={(e) => setPairSymbol(e.target.value)}
+                      className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                    >
+                      {pairs.map((pair) => (
+                        <option key={pair.id} value={pair.symbol}>
+                          {pair.symbol} ({pair.category})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Timeframe</label>
+                      <select
+                        value={timeframe}
+                        onChange={(e) => setTimeframe(e.target.value)}
+                        className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                      >
+                        {TIMEFRAMES.map((value) => (
+                          <option key={value} value={value}>{value}</option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Market Session</label>
+                      <select
+                        value={marketSession}
+                        onChange={(e) => setMarketSession(e.target.value)}
+                        className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                      >
+                        {SESSIONS.map((value) => (
+                          <option key={value} value={value}>{value}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Directional Bias</label>
+                    <select
+                      value={directionalBiasInput}
+                      onChange={(e) => setDirectionalBiasInput(e.target.value)}
+                      className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                    >
+                      {BIASES.map((value) => (
+                        <option key={value} value={value} className="capitalize">{value}</option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Setup Notes (optional)</label>
+                    <textarea
+                      value={setupNotes}
+                      onChange={(e) => setSetupNotes(e.target.value)}
+                      rows={4}
+                      placeholder="Context, structure, and execution notes..."
+                      className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                    />
+                  </div>
+
+                  <div className="grid gap-3 md:grid-cols-3">
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Entry (optional)</label>
+                      <input
+                        type="number"
+                        step="any"
+                        value={plannedEntry}
+                        onChange={(e) => setPlannedEntry(e.target.value)}
+                        className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Stop Loss (optional)</label>
+                      <input
+                        type="number"
+                        step="any"
+                        value={plannedStopLoss}
+                        onChange={(e) => setPlannedStopLoss(e.target.value)}
+                        className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Take Profit (optional)</label>
+                      <input
+                        type="number"
+                        step="any"
+                        value={plannedTakeProfit}
+                        onChange={(e) => setPlannedTakeProfit(e.target.value)}
+                        className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                      />
+                    </div>
+                  </div>
+
+                  {globalError && (
+                    <div className="rounded-md border border-red-300 bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-700 dark:text-red-300">
+                      {globalError}
+                    </div>
+                  )}
+
+                  <Button type="submit" disabled={!canSubmit || submitting} className="w-full">
+                    {submitting ? "Generating Brief..." : "Generate Pre-Trade Brief"}
+                  </Button>
+                </form>
+              </section>
+
+              <section className="bg-white dark:bg-[#161B22] border border-gray-200 dark:border-gray-800 rounded-xl p-5">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Latest Generated Brief</h2>
+                {!result ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Submit the form to generate your first brief.</p>
+                ) : (
+                  <div className="space-y-4">
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Summary</h3>
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">{result.ai_summary}</p>
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Bias</h3>
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">{result.ai_bias}</p>
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Confluence</h3>
+                      {renderList(result.ai_confluence || [])}
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Risks</h3>
+                      {renderList(result.ai_risks || [])}
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Invalidation</h3>
+                      {renderList(result.ai_invalidators || [])}
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Checklist</h3>
+                      {renderList(result.ai_checklist || [])}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      Pair: {result.pair_symbol_snapshot} · Timeframe: {result.timeframe} · Session: {result.market_session}
+                      {result.risk_reward_ratio != null ? ` · R:R ${result.risk_reward_ratio}` : ""}
+                    </div>
+                  </div>
+                )}
+              </section>
+            </div>
+
+            <div className="mt-6 grid gap-6 lg:grid-cols-5">
+              <section className="lg:col-span-2 bg-white dark:bg-[#161B22] border border-gray-200 dark:border-gray-800 rounded-xl p-5">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Recent Saved Briefs</h2>
+                {!recentBriefs.length ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">No briefs saved yet.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {recentBriefs.map((brief) => {
+                      const selected = brief.id === selectedBriefId;
+                      return (
+                        <button
+                          key={brief.id}
+                          onClick={() => setSelectedBriefId(brief.id)}
+                          className={`w-full text-left border rounded-lg p-3 transition-colors ${
+                            selected
+                              ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                              : "border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-[#0f141b]"
+                          }`}
+                        >
+                          <div className="font-medium text-gray-900 dark:text-gray-100">
+                            {brief.pair_symbol_snapshot} · {brief.timeframe}
+                          </div>
+                          <div className="text-xs text-gray-600 dark:text-gray-300 mt-1">
+                            {brief.market_session} · {brief.directional_bias_input} · {brief.status}
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">{formatDate(brief.created_at)}</div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+
+              <section className="lg:col-span-3 bg-white dark:bg-[#161B22] border border-gray-200 dark:border-gray-800 rounded-xl p-5">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Brief Detail & Workflow</h2>
+
+                {detailLoading ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Loading detail...</p>
+                ) : detailError ? (
+                  <p className="text-sm text-red-600 dark:text-red-300">{detailError}</p>
+                ) : !selectedBrief ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Select a saved brief to inspect and update it.</p>
+                ) : (
+                  <div className="space-y-4">
+                    <div className="grid md:grid-cols-2 gap-3 text-sm">
+                      <div><span className="font-medium">Pair:</span> {selectedBrief.pair_symbol_snapshot}</div>
+                      <div><span className="font-medium">Timeframe:</span> {selectedBrief.timeframe}</div>
+                      <div><span className="font-medium">Session:</span> {selectedBrief.market_session}</div>
+                      <div><span className="font-medium">Directional idea:</span> {selectedBrief.directional_bias_input}</div>
+                      <div><span className="font-medium">Entry:</span> {selectedBrief.planned_entry ?? "N/A"}</div>
+                      <div><span className="font-medium">Stop Loss:</span> {selectedBrief.planned_stop_loss ?? "N/A"}</div>
+                      <div><span className="font-medium">Take Profit:</span> {selectedBrief.planned_take_profit ?? "N/A"}</div>
+                      <div><span className="font-medium">R:R:</span> {selectedBrief.risk_reward_ratio ?? "N/A"}</div>
+                      <div><span className="font-medium">Created:</span> {formatDate(selectedBrief.created_at)}</div>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Current Status</label>
+                      <select
+                        value={statusDraft}
+                        onChange={(e) => setStatusDraft(e.target.value as EditablePreTradeBriefStatus)}
+                        className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                      >
+                        {EDITABLE_STATUSES.map((statusOption) => (
+                          <option value={statusOption} key={statusOption}>
+                            {statusOption}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Setup Notes</h3>
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">{selectedBrief.setup_notes || "N/A"}</p>
+                    </div>
+
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Summary</h3>
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">{selectedBrief.ai_summary || "N/A"}</p>
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Bias</h3>
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">{selectedBrief.ai_bias || "N/A"}</p>
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Confluence</h3>
+                      {renderList(selectedBrief.ai_confluence || [])}
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Risks</h3>
+                      {renderList(selectedBrief.ai_risks || [])}
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Invalidation</h3>
+                      {renderList(selectedBrief.ai_invalidators || [])}
+                    </div>
+
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white mb-2">Checklist Progress</h3>
+                      <div className="space-y-2">
+                        {(selectedBrief.ai_checklist || []).map((item, idx) => {
+                          const checked = checklistStateDraft[item]?.completed || false;
+                          return (
+                            <label key={`${item}-${idx}`} className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={(e) => toggleChecklistItem(item, e.target.checked)}
+                                className="mt-1"
+                              />
+                              <span>{item}</span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Trader Notes</label>
+                      <textarea
+                        rows={4}
+                        value={traderNotesDraft}
+                        onChange={(e) => setTraderNotesDraft(e.target.value)}
+                        placeholder="Add your own execution notes and reminders..."
+                        className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                      />
+                    </div>
+
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      Decision-support only. This brief does not guarantee outcomes.
+                    </div>
+
+                    <Button onClick={handleSaveDetail} disabled={savingDetail}>
+                      {savingDetail ? "Saving..." : "Save Notes, Checklist & Status"}
+                    </Button>
+                  </div>
+                )}
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PreTradeBriefPage() {
+  return (
+    <LayoutClient>
+      <PreTradeBriefContent />
+    </LayoutClient>
+  );
+}

--- a/database/migrations/2026-04-09_add_pre_trade_brief_review_fields.sql
+++ b/database/migrations/2026-04-09_add_pre_trade_brief_review_fields.sql
@@ -1,0 +1,13 @@
+-- Add review/edit support fields for pre_trade_briefs
+ALTER TABLE pre_trade_briefs
+  ADD COLUMN IF NOT EXISTS trader_notes TEXT,
+  ADD COLUMN IF NOT EXISTS checklist_state JSONB,
+  ADD COLUMN IF NOT EXISTS last_reviewed_at TIMESTAMPTZ;
+
+-- Expand status values for light workflow updates
+ALTER TABLE pre_trade_briefs
+  DROP CONSTRAINT IF EXISTS pre_trade_briefs_status_check;
+
+ALTER TABLE pre_trade_briefs
+  ADD CONSTRAINT pre_trade_briefs_status_check
+  CHECK (status IN ('generated', 'draft', 'ready', 'invalidated', 'executed', 'skipped', 'failed'));

--- a/database/migrations/2026-04-09_create_forex_pre_trade_briefs.sql
+++ b/database/migrations/2026-04-09_create_forex_pre_trade_briefs.sql
@@ -1,0 +1,120 @@
+-- Create minimal Forex pre-trade brief slice
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Forex pairs reference table
+CREATE TABLE IF NOT EXISTS forex_pairs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  symbol TEXT NOT NULL UNIQUE,
+  base_currency TEXT NOT NULL,
+  quote_currency TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'major',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_forex_pairs_symbol ON forex_pairs(symbol);
+CREATE INDEX IF NOT EXISTS idx_forex_pairs_active ON forex_pairs(is_active) WHERE is_active = true;
+
+-- Seed initial active pairs
+INSERT INTO forex_pairs (symbol, base_currency, quote_currency, category, is_active)
+VALUES
+  ('EURUSD', 'EUR', 'USD', 'major', true),
+  ('GBPUSD', 'GBP', 'USD', 'major', true),
+  ('USDJPY', 'USD', 'JPY', 'major', true),
+  ('AUDUSD', 'AUD', 'USD', 'major', true),
+  ('USDCAD', 'USD', 'CAD', 'major', true),
+  ('USDCHF', 'USD', 'CHF', 'major', true),
+  ('NZDUSD', 'NZD', 'USD', 'major', true),
+  ('EURJPY', 'EUR', 'JPY', 'cross', true),
+  ('GBPJPY', 'GBP', 'JPY', 'cross', true)
+ON CONFLICT (symbol) DO NOTHING;
+
+-- Pre-trade brief records
+CREATE TABLE IF NOT EXISTS pre_trade_briefs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  forex_pair_id UUID NOT NULL REFERENCES forex_pairs(id) ON DELETE RESTRICT,
+  pair_symbol_snapshot TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  market_session TEXT NOT NULL,
+  directional_bias_input TEXT NOT NULL,
+  setup_notes TEXT,
+  planned_entry NUMERIC,
+  planned_stop_loss NUMERIC,
+  planned_take_profit NUMERIC,
+  risk_reward_ratio NUMERIC,
+  ai_summary TEXT,
+  ai_bias TEXT,
+  ai_confluence TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ai_risks TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ai_invalidators TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ai_checklist TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  raw_ai_response JSONB,
+  status TEXT NOT NULL DEFAULT 'generated',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT pre_trade_briefs_status_check CHECK (status IN ('generated', 'draft', 'failed')),
+  CONSTRAINT pre_trade_briefs_price_check CHECK (
+    (planned_entry IS NULL AND planned_stop_loss IS NULL AND planned_take_profit IS NULL)
+    OR (planned_entry IS NOT NULL AND planned_stop_loss IS NOT NULL AND planned_take_profit IS NOT NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_pre_trade_briefs_user_id_created_at ON pre_trade_briefs(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_pre_trade_briefs_forex_pair_id ON pre_trade_briefs(forex_pair_id);
+CREATE INDEX IF NOT EXISTS idx_pre_trade_briefs_status ON pre_trade_briefs(status);
+
+-- Updated timestamp trigger
+CREATE OR REPLACE FUNCTION trg_pre_trade_briefs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_pre_trade_briefs_updated_at ON pre_trade_briefs;
+CREATE TRIGGER trigger_pre_trade_briefs_updated_at
+  BEFORE UPDATE ON pre_trade_briefs
+  FOR EACH ROW
+  EXECUTE FUNCTION trg_pre_trade_briefs_updated_at();
+
+-- RLS setup
+ALTER TABLE forex_pairs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE pre_trade_briefs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS forex_pairs_read_all ON forex_pairs;
+CREATE POLICY forex_pairs_read_all
+ON forex_pairs
+FOR SELECT
+TO authenticated, anon
+USING (true);
+
+DROP POLICY IF EXISTS pre_trade_briefs_select_own ON pre_trade_briefs;
+CREATE POLICY pre_trade_briefs_select_own
+ON pre_trade_briefs
+FOR SELECT
+TO authenticated
+USING (auth.uid()::text = user_id::text);
+
+DROP POLICY IF EXISTS pre_trade_briefs_insert_own ON pre_trade_briefs;
+CREATE POLICY pre_trade_briefs_insert_own
+ON pre_trade_briefs
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid()::text = user_id::text);
+
+DROP POLICY IF EXISTS pre_trade_briefs_update_own ON pre_trade_briefs;
+CREATE POLICY pre_trade_briefs_update_own
+ON pre_trade_briefs
+FOR UPDATE
+TO authenticated
+USING (auth.uid()::text = user_id::text)
+WITH CHECK (auth.uid()::text = user_id::text);
+
+DROP POLICY IF EXISTS pre_trade_briefs_delete_own ON pre_trade_briefs;
+CREATE POLICY pre_trade_briefs_delete_own
+ON pre_trade_briefs
+FOR DELETE
+TO authenticated
+USING (auth.uid()::text = user_id::text);

--- a/forex-agent/PLAN.md
+++ b/forex-agent/PLAN.md
@@ -1,0 +1,325 @@
+# Forex Agent Workspace Plan
+
+## 1) Purpose of the `forex-agent` workspace
+
+`forex-agent/` is a focused internal workspace for designing and validating a **Forex-only execution intelligence layer** inside Tradia. It is a planning-first area to define product scope, workflows, data contracts, and integration strategy before shipping features into the main app.
+
+This workspace is intentionally isolated so we can iterate quickly on:
+- execution-focused product concepts,
+- schema and API design,
+- AI-assisted workflow logic,
+- integration plans for Tradia’s existing stack.
+
+---
+
+## 2) How it fits Tradia’s vision
+
+Tradia is already an AI Trading Journal for Forex and prop firm traders. The `forex-agent` initiative extends that vision from:
+- **recording and analyzing what happened** (journal + analytics)
+
+to:
+- **improving what happens next** (execution intelligence before, during, and after a trade).
+
+In short: journaling remains core; `forex-agent` adds a decision-support layer around execution quality.
+
+---
+
+## 3) Why this belongs inside Tradia (not a separate repo)
+
+Build inside Tradia because the value depends on existing user context and data:
+- Existing Forex pair analytics and session analytics are direct inputs.
+- Risk tools and AI insights already provide relevant foundations.
+- Current users (Forex + prop firm traders) are the same target users.
+- Next.js + Supabase architecture and auth can be reused.
+- Shared design system and dashboard UX reduce implementation cost.
+
+Separate repo costs (sync complexity, duplicated auth/schema/UI, slower iteration) would hurt a solo builder.
+
+---
+
+## 4) Product concept
+
+### Forex execution intelligence workspace
+A structured workflow that guides traders from idea to review with consistent, context-aware support.
+
+### Pre-trade analysis
+- Pair context snapshot (trend, volatility, session, recent behavior).
+- Setup quality scoring using user-defined playbooks.
+- Risk conditions check before order placement.
+
+### Market bias support
+- Multi-timeframe directional bias notes.
+- Scenario mapping (base case / invalidation / alternate case).
+- Bias confidence with explicit assumptions.
+
+### News/event awareness
+- Highlight high-impact macro events and session-relevant releases.
+- Surface “avoid/size down/wait” guidance windows.
+- Link event risk to setup confidence.
+
+### Trade planning
+- Entry thesis, invalidation, targets, risk %, and execution checklist.
+- Firm-rule-safe plan constraints for prop/funded accounts.
+- One-page pre-trade brief for decision clarity.
+
+### Post-trade review support
+- Compare execution vs plan.
+- Detect rule breaks, emotional deviations, and process drift.
+- Generate structured improvement actions for the next session.
+
+---
+
+## 5) Clear target users
+
+1. **Forex pair traders** (major/minor/cross pairs, session-aware execution).
+2. **Prop firm traders** (drawdown/consistency/rule-constrained behavior).
+3. **Funded traders** (capital protection + repeatable execution process).
+
+---
+
+## 6) Core problems solved beyond a journal alone
+
+A journal is excellent for hindsight analysis, but execution problems often happen before logging:
+- No standardized pre-trade decision process.
+- Bias changes are undocumented and inconsistent.
+- Event risk is known but not operationalized.
+- Plan quality varies trade-to-trade.
+- Rule compliance checks are ad hoc.
+- Post-trade lessons are not turned into executable next-step constraints.
+
+`forex-agent` closes this gap by operationalizing process quality, not just recording outcomes.
+
+---
+
+## 7) What ideas to study from AI-Trader
+
+Use AI-Trader only as idea reference for:
+- Agent-style workflow decomposition (pre-trade, execution, review).
+- Trade lifecycle orchestration patterns.
+- Structured prompts/checklists instead of free-form chat only.
+- Clear state transitions (idea -> plan -> execute -> review).
+- Human-in-the-loop recommendations with explicit rationale.
+
+---
+
+## 8) What NOT to import from AI-Trader
+
+Do not copy or replicate:
+- Branding, product positioning, or UX identity.
+- Codebase architecture assumptions that conflict with Next.js/Supabase.
+- Data models that ignore Tradia’s current entities and analytics.
+- Generic multi-asset behavior that dilutes Forex-first focus.
+- Opaque “auto-trading” behavior that removes user control.
+
+Principle: borrow workflow ideas, not implementation or product identity.
+
+---
+
+## 9) Alignment with Tradia architecture
+
+### Next.js App Router
+- Keep integration targets aligned with existing `app/` routing patterns.
+- Introduce features gradually as dashboard modules, not a parallel app.
+
+### Existing dashboard structure
+- Reuse dashboard shells, navigation, auth guards, and layout conventions.
+- Expose forex-agent outputs in familiar analytics/review surfaces.
+
+### `app/api`
+- Add dedicated API handlers for brief generation, bias reporting, and reviews.
+- Keep contracts typed and compatible with existing auth/session checks.
+
+### `src/components`
+- Build reusable Forex-agent UI blocks (brief cards, checklist panels, review diffs).
+- Reuse existing component primitives/design tokens.
+
+### `src/lib`
+- Add domain services for scoring logic, event normalization, and AI orchestration.
+- Keep side effects and provider clients centralized.
+
+### Supabase-backed data model
+- Add normalized tables with clear foreign keys to users/accounts/trades.
+- Use RLS-compatible ownership and access patterns from existing schema.
+
+---
+
+## 10) Recommended internal folder structure for `forex-agent/`
+
+```text
+forex-agent/
+  PLAN.md
+  README.md                       # short workspace entrypoint
+  research/
+    ai-trader-notes.md            # extracted ideas, no copied code
+    user-workflows.md             # current vs target trader workflows
+    constraints.md                # product, legal, and technical boundaries
+  product/
+    problem-statements.md
+    user-personas.md
+    execution-workflow.md
+    feature-scope-mvp.md
+  architecture/
+    integration-map.md            # how modules map into app/api/src
+    domain-model.md               # entities and relationships
+    supabase-schema-draft.sql     # draft tables (planning only initially)
+    api-contracts.md              # request/response drafts
+  ai/
+    prompt-strategy.md
+    evaluation-rubric.md
+    guardrails.md
+  rollout/
+    phase-plan.md
+    migration-checklist.md
+    success-metrics.md
+```
+
+---
+
+## 11) Proposed data models
+
+> Note: final schema should be adapted to current Tradia tables and naming conventions.
+
+### `forex_pairs`
+Purpose: canonical FX instruments and metadata.
+- `id` (uuid, pk)
+- `symbol` (text, unique) — e.g., EURUSD
+- `base_currency` (text)
+- `quote_currency` (text)
+- `pip_precision` (int)
+- `session_profile` (jsonb) — active sessions, typical volatility bands
+- `is_active` (bool)
+- `created_at`, `updated_at`
+
+### `market_bias_reports`
+Purpose: timestamped directional/context views per pair.
+- `id` (uuid, pk)
+- `user_id` (uuid, fk)
+- `pair_id` (uuid, fk -> forex_pairs)
+- `timeframe_set` (jsonb)
+- `bias_direction` (text) — bullish/bearish/neutral
+- `confidence_score` (numeric)
+- `key_levels` (jsonb)
+- `assumptions` (text)
+- `invalidation_conditions` (text)
+- `source` (text) — manual/ai/hybrid
+- `created_at`, `updated_at`
+
+### `economic_events`
+Purpose: event calendar entries normalized for execution workflows.
+- `id` (uuid, pk)
+- `provider_event_id` (text, unique nullable)
+- `title` (text)
+- `country` (text)
+- `currency` (text)
+- `impact` (text) — low/medium/high
+- `scheduled_at` (timestamptz)
+- `actual` (text nullable)
+- `forecast` (text nullable)
+- `previous` (text nullable)
+- `event_type` (text)
+- `created_at`, `updated_at`
+
+### `trade_setups`
+Purpose: structured setup definitions tied to pair + session + playbook.
+- `id` (uuid, pk)
+- `user_id` (uuid, fk)
+- `pair_id` (uuid, fk)
+- `setup_name` (text)
+- `setup_type` (text)
+- `timeframe` (text)
+- `session` (text)
+- `confluence_factors` (jsonb)
+- `quality_score` (numeric)
+- `status` (text) — draft/ready/invalidated/executed
+- `created_at`, `updated_at`
+
+### `execution_checklists`
+Purpose: repeatable rule checks before execution.
+- `id` (uuid, pk)
+- `user_id` (uuid, fk)
+- `name` (text)
+- `account_type` (text) — personal/prop/funded
+- `items` (jsonb) — checklist item definitions
+- `is_default` (bool)
+- `created_at`, `updated_at`
+
+### `pre_trade_briefs`
+Purpose: frozen plan snapshot before entry.
+- `id` (uuid, pk)
+- `user_id` (uuid, fk)
+- `pair_id` (uuid, fk)
+- `setup_id` (uuid, fk -> trade_setups)
+- `bias_report_id` (uuid, fk -> market_bias_reports)
+- `checklist_id` (uuid, fk -> execution_checklists)
+- `entry_plan` (jsonb)
+- `risk_plan` (jsonb)
+- `event_risk_summary` (text)
+- `approval_state` (text) — ready/blocked/manual-override
+- `created_at`, `updated_at`
+
+### `post_trade_reviews`
+Purpose: plan-vs-execution feedback loop.
+- `id` (uuid, pk)
+- `user_id` (uuid, fk)
+- `trade_id` (uuid, fk to existing trades table)
+- `brief_id` (uuid, fk -> pre_trade_briefs)
+- `execution_grade` (numeric)
+- `rule_violations` (jsonb)
+- `process_mistakes` (jsonb)
+- `what_worked` (text)
+- `improvements_next_trade` (text)
+- `ai_summary` (text)
+- `created_at`, `updated_at`
+
+---
+
+## 12) Suggested phases
+
+### Phase 1: research and planning
+- Validate user workflows (pair trader, prop trader, funded trader).
+- Define MVP scope and non-goals.
+- Finalize domain model and initial API contracts.
+
+### Phase 2: data models and adapters
+- Draft Supabase migrations for core tables.
+- Build server-side adapters for economic events and pair metadata.
+- Add internal service layer contracts in `src/lib` (no major UI yet).
+
+### Phase 3: UI integration into dashboard
+- Introduce pre-trade brief and checklist modules in existing dashboard.
+- Add market bias and event awareness panels.
+- Ensure consistency with existing navigation and analytics pages.
+
+### Phase 4: AI analysis features
+- Add AI-assisted brief generation and post-trade review summaries.
+- Implement guardrails, confidence display, and override UX.
+- Track quality metrics (adoption, checklist completion, execution drift).
+
+---
+
+## 13) Risks, constraints, and boundaries
+
+- **Scope creep risk:** too many agent features too early; enforce MVP.
+- **Data quality risk:** event/calendar data reliability affects trust.
+- **Over-automation risk:** recommendations must not become blind signals.
+- **Latency/cost risk:** AI calls in workflow-critical surfaces need caching/fallbacks.
+- **Compliance/expectation risk:** clearly position as decision support, not guaranteed outcomes.
+- **Integration risk:** avoid parallel architecture; integrate with existing app conventions.
+- **Solo builder constraint:** prioritize modular, incremental delivery over big-bang redesign.
+
+Boundaries:
+- No direct execution/broker automation in initial phases.
+- No full repo restructure.
+- No separate product identity outside Tradia.
+
+---
+
+## 14) Exact next implementation step after `PLAN.md`
+
+Create `forex-agent/README.md` as the execution entrypoint with:
+1. MVP scope (in/out),
+2. accepted glossary (bias, setup, brief, review),
+3. links to planned docs in `research/`, `product/`, and `architecture/`,
+4. a short “first 7 implementation tasks” checklist ordered by dependency.
+
+This keeps planning actionable while still avoiding premature code changes.

--- a/forex-agent/README.md
+++ b/forex-agent/README.md
@@ -1,0 +1,36 @@
+# Forex Agent Workspace
+
+## What this is
+`forex-agent/` is an internal planning workspace for building Tradia’s **Forex execution intelligence layer**. It is not a standalone product and not a separate app. It is a design-and-architecture area where product logic, data contracts, workflow specs, and AI behavior are defined before production implementation.
+
+## Why it exists inside Tradia
+Tradia already has the right audience (Forex, prop, funded traders), the right product surface (journal + analytics), and the right technical foundations (Next.js + Supabase + AI insights). Building this workspace inside Tradia keeps:
+- data context unified,
+- user workflow continuity intact,
+- implementation cost and complexity low.
+
+## Current phase
+Current phase is **internal planning and architecture design**:
+- no new routes,
+- no UI implementation,
+- no dashboard modification,
+- no migration execution.
+
+This folder should produce implementation-ready artifacts so the next phase can ship with minimal ambiguity.
+
+## Subfolders
+- `docs/`: product and system design references that define what to build and why.
+- `schemas/`: TypeScript-first draft entity schemas and validation constraints.
+- `adapters/`: integration notes for external/internal data and AI orchestration boundaries.
+- `prompts/`: prompt contracts for pre-trade, bias, and post-trade AI analysis.
+- `research/`: distilled notes from AI-Trader-style references and lessons applicable to Tradia.
+
+## Suggested reading order
+1. `PLAN.md`
+2. `docs/product-spec.md`
+3. `docs/architecture.md`
+4. `docs/integration-map.md`
+5. `docs/data-models.md`
+6. `docs/execution-workflows.md`
+7. `docs/ai-analysis-spec.md`
+8. `schemas/` and `prompts/`

--- a/forex-agent/adapters/ai-analysis.adapter.md
+++ b/forex-agent/adapters/ai-analysis.adapter.md
@@ -1,0 +1,26 @@
+# Adapter Spec — AI Analysis
+
+## Why this adapter exists
+Centralize LLM interaction for brief, bias, and review tasks with consistent guardrails and schema enforcement.
+
+## Data source
+Internal AI provider abstraction (existing Tradia AI infrastructure / model gateway).
+
+## Expected inputs
+- analysis type (`pre_trade_brief` | `market_bias` | `post_trade_review`)
+- normalized domain payload
+- prompt template version
+- user/account constraints (risk rules, account type)
+
+## Expected outputs
+- structured JSON result per analysis type
+- confidence + rationale blocks
+- safety flags (insufficient context, overconfident language)
+- prompt/model metadata for auditing
+
+## Implementation concerns
+- strict output schema validation and retries
+- token cost + latency management
+- refusal/fallback behavior when inputs are incomplete
+- prompt versioning and regression testing
+- redaction of sensitive account data before model calls

--- a/forex-agent/adapters/economic-calendar.adapter.md
+++ b/forex-agent/adapters/economic-calendar.adapter.md
@@ -1,0 +1,25 @@
+# Adapter Spec — Economic Calendar
+
+## Why this adapter exists
+Event risk must be surfaced in a trader-friendly format and tied to planned trade windows.
+
+## Data source
+Planned external calendar provider(s) with fallback strategy; optional internal normalized cache in Supabase.
+
+## Expected inputs
+- `currencies` (e.g., ["USD", "EUR"])
+- `from` / `to` datetime range
+- optional `impactFilter` (high/medium/low)
+
+## Expected outputs
+- normalized economic events list
+- impact tier and scheduled timestamp
+- provider IDs for traceability
+- event risk window hints for planning logic
+
+## Implementation concerns
+- event revisions after publication
+- daylight saving and locale timestamp mismatches
+- deduplication when using multiple providers
+- stale event cache invalidation
+- deterministic sorting by scheduled time + impact

--- a/forex-agent/adapters/journaling.adapter.md
+++ b/forex-agent/adapters/journaling.adapter.md
@@ -1,0 +1,23 @@
+# Adapter Spec — Journaling Bridge
+
+## Why this adapter exists
+Forex-agent must consume existing trade/journal context and write review artifacts without duplicating Tradia’s core journaling domain.
+
+## Data source
+Internal Tradia journal/trade entities in Supabase and existing backend APIs.
+
+## Expected inputs
+- `tradeId` or recent trade query filters
+- user/account identifiers
+- optional pre-trade brief reference
+
+## Expected outputs
+- normalized trade execution snapshot (entry, stop, exits, timing, notes)
+- plan-vs-execution comparison payload
+- write contracts for `post_trade_reviews`
+
+## Implementation concerns
+- field-level mapping drift if trade schema evolves
+- missing legacy trade metadata for older records
+- ownership and RLS constraints for cross-table joins
+- idempotent write behavior for repeated review generation

--- a/forex-agent/adapters/market-data.adapter.md
+++ b/forex-agent/adapters/market-data.adapter.md
@@ -1,0 +1,26 @@
+# Adapter Spec — Market Data
+
+## Why this adapter exists
+Forex-agent needs normalized pair context (recent price structure, volatility cues, session behavior) regardless of provider format.
+
+## Data source
+Planned connection to internal market data service or approved external FX feed used elsewhere in Tradia.
+
+## Expected inputs
+- `pairSymbol` (e.g., EURUSD)
+- `timeframes` (array: H4/H1/M15)
+- `lookbackWindow` (candles or time range)
+- optional `sessionContext`
+
+## Expected outputs
+- normalized OHLC summary blocks by timeframe
+- derived levels candidates (swing highs/lows)
+- volatility markers (ATR-like proxy or range percentile)
+- freshness metadata (source timestamp, lag)
+
+## Implementation concerns
+- provider outages and partial responses
+- timeframe synchronization consistency
+- timezone normalization (UTC internal)
+- cache strategy for repeated pair/timeframe requests
+- strict schema validation before AI consumption

--- a/forex-agent/docs/ai-analysis-spec.md
+++ b/forex-agent/docs/ai-analysis-spec.md
@@ -1,0 +1,65 @@
+# AI Analysis Spec (Decision-Support Only)
+
+## Role of AI in Forex-agent
+AI acts as a **structured analysis assistant** that helps users create consistent plans and reviews. It is not an auto-trading engine and not a certainty signal provider.
+
+## What AI should do
+- Summarize complex context into concise trader-facing outputs.
+- Highlight assumptions, invalidation, and risk dependencies.
+- Flag conflicts between setup quality and checklist requirements.
+- Produce post-trade process feedback with actionable corrections.
+- Emit machine-readable output for UI/API consumption.
+
+## What AI must never do
+- Guarantee outcomes or claim high-probability certainty.
+- Use “take this trade now” directive language.
+- Hide uncertainty or skip invalidation conditions.
+- Encourage risk escalation after losses.
+- Replace trader judgment or prop-firm rule constraints.
+
+## Output contracts
+
+### A) Pre-trade brief output
+Must include:
+- `market_context`
+- `setup_summary`
+- `entry_plan`
+- `risk_plan`
+- `event_risk_summary`
+- `checklist_findings`
+- `approval_recommendation` (`ready|blocked|manual_override`)
+- `confidence` + `confidence_rationale`
+
+### B) Market bias report output
+Must include:
+- `bias_direction`
+- `timeframe_alignment`
+- `key_levels`
+- `assumptions`
+- `invalidation_conditions`
+- `alternate_scenario`
+- `confidence`
+
+### C) Post-trade review output
+Must include:
+- `plan_vs_execution_diff`
+- `rule_violations`
+- `process_mistakes`
+- `what_worked`
+- `top_3_improvements`
+- `next_trade_focus`
+- `confidence`
+
+## Safety and trust rules
+1. **No guaranteed predictions.**
+2. **No certainty framing** (“must win”, “safe trade”, “guaranteed setup”).
+3. **Decision-support only** with explicit uncertainty.
+4. Always show invalidation and risk constraints.
+5. If inputs are incomplete, return “insufficient context” with missing fields list.
+6. Preserve traceability: include rationale snippets tied to provided inputs.
+
+## Quality controls (phase 4)
+- Schema validation for all AI responses.
+- Hallucination checks against input payload fields.
+- Confidence calibration based on input completeness.
+- Prompt regression set for pre-trade/bias/review artifacts.

--- a/forex-agent/docs/architecture.md
+++ b/forex-agent/docs/architecture.md
@@ -1,0 +1,71 @@
+# Architecture (Planning Mode)
+
+## Objective
+Define how Forex execution intelligence will integrate into Tradia without introducing a parallel system.
+
+## High-level fit
+- Keep `forex-agent/` as design source-of-truth.
+- Implement production features incrementally in existing Tradia app layers.
+- Reuse existing auth, dashboard shell, and Supabase ownership model.
+
+## Future integration points
+
+### `app/` (Next.js App Router)
+Likely future pages/modules (not created yet):
+- dashboard modules for pre-trade briefs,
+- market bias summaries,
+- post-trade review cards.
+
+Guideline: integrate as additions to existing dashboard flows, not a new app subtree.
+
+### `app/api/`
+Planned endpoint categories:
+- `/api/forex-agent/pre-trade-brief`
+- `/api/forex-agent/market-bias`
+- `/api/forex-agent/post-trade-review`
+- `/api/forex-agent/economic-events` (normalized retrieval)
+
+Guideline: thin route handlers, domain logic delegated to `src/lib/` services.
+
+### `src/components/`
+Planned reusable UI blocks:
+- `PreTradeBriefCard`
+- `BiasReportPanel`
+- `ExecutionChecklist`
+- `PostTradeReviewSummary`
+
+Guideline: compose from existing design primitives; avoid style system divergence.
+
+### `src/lib/`
+Planned service modules:
+- `forex-agent/bias-service`
+- `forex-agent/brief-service`
+- `forex-agent/review-service`
+- `forex-agent/event-service`
+- `forex-agent/validation`
+
+Guideline: pure functions and typed contracts; centralize provider clients and guardrails.
+
+### Supabase
+Planned tables:
+- `forex_pairs`
+- `market_bias_reports`
+- `economic_events`
+- `trade_setups`
+- `execution_checklists`
+- `pre_trade_briefs`
+- `post_trade_reviews`
+
+Guideline: align with existing user/trade/account relations and RLS strategy.
+
+## Boundaries: planning workspace vs production code
+- `forex-agent/` holds design docs, schema drafts, prompt contracts.
+- No imports from `forex-agent/` into runtime code until implementation phase.
+- No route creation, migrations, or UI code in this phase.
+
+## Solo-builder implementation strategy
+1. Freeze docs and schema contracts.
+2. Implement data layer and adapters first.
+3. Add internal APIs and integration tests.
+4. Add minimal UI surfaces in existing dashboard.
+5. Iterate AI analysis quality with guardrails and observability.

--- a/forex-agent/docs/data-models.md
+++ b/forex-agent/docs/data-models.md
@@ -1,0 +1,174 @@
+# Data Models (Draft)
+
+All entities are planning artifacts for later Supabase migration design.
+
+## 1) `forex_pairs`
+### Purpose
+Canonical Forex instrument reference and metadata used by setups, briefs, and bias reports.
+
+### Fields
+- `id: uuid` (PK)
+- `symbol: text` (unique, uppercase, e.g., `EURUSD`)
+- `base_currency: text` (3-letter code)
+- `quote_currency: text` (3-letter code)
+- `pip_precision: integer`
+- `session_profile: jsonb` (active sessions, volatility notes)
+- `is_active: boolean`
+- `created_at: timestamptz`
+- `updated_at: timestamptz`
+
+### Relationships
+Referenced by `market_bias_reports`, `trade_setups`, `pre_trade_briefs`.
+
+### Validation notes
+- enforce uppercase symbol/currencies
+- pip precision must be > 0
+
+## 2) `market_bias_reports`
+### Purpose
+Stores directional context snapshots for a pair at a point in time.
+
+### Fields
+- `id: uuid` (PK)
+- `user_id: uuid` (FK users)
+- `pair_id: uuid` (FK forex_pairs)
+- `timeframe_set: jsonb` (e.g., H4/H1/M15)
+- `bias_direction: text` (`bullish|bearish|neutral`)
+- `confidence_score: numeric` (0–100)
+- `key_levels: jsonb` (support/resistance/invalidation)
+- `assumptions: text`
+- `invalidation_conditions: text`
+- `source: text` (`manual|ai|hybrid`)
+- `created_at: timestamptz`
+- `updated_at: timestamptz`
+
+### Relationships
+Belongs to user + pair. May be linked by `pre_trade_briefs`.
+
+### Validation notes
+- confidence range check
+- require non-empty invalidation text
+
+## 3) `economic_events`
+### Purpose
+Normalized economic calendar entries consumed by planning workflows.
+
+### Fields
+- `id: uuid` (PK)
+- `provider_event_id: text` (unique nullable)
+- `title: text`
+- `country: text`
+- `currency: text`
+- `impact: text` (`low|medium|high`)
+- `scheduled_at: timestamptz`
+- `actual: text | null`
+- `forecast: text | null`
+- `previous: text | null`
+- `event_type: text`
+- `is_all_day: boolean`
+- `created_at: timestamptz`
+- `updated_at: timestamptz`
+
+### Relationships
+Referenced by briefs (via join table or denormalized selected event IDs).
+
+### Validation notes
+- scheduled_at must be present
+- impact enumeration required
+
+## 4) `trade_setups`
+### Purpose
+Captures a tradable setup definition before execution.
+
+### Fields
+- `id: uuid` (PK)
+- `user_id: uuid` (FK users)
+- `pair_id: uuid` (FK forex_pairs)
+- `setup_name: text`
+- `setup_type: text` (breakout, pullback, reversal, etc.)
+- `timeframe: text`
+- `session: text` (Asia/London/NY/Overlap)
+- `confluence_factors: jsonb`
+- `quality_score: numeric` (0–100)
+- `status: text` (`draft|ready|invalidated|executed`)
+- `created_at: timestamptz`
+- `updated_at: timestamptz`
+
+### Relationships
+Can feed multiple briefs; belongs to user + pair.
+
+### Validation notes
+- setup_name min length
+- quality score range check
+
+## 5) `execution_checklists`
+### Purpose
+Reusable user-specific checklist templates for execution discipline.
+
+### Fields
+- `id: uuid` (PK)
+- `user_id: uuid` (FK users)
+- `name: text`
+- `account_type: text` (`personal|prop|funded`)
+- `items: jsonb` (array of checklist item definitions)
+- `is_default: boolean`
+- `created_at: timestamptz`
+- `updated_at: timestamptz`
+
+### Relationships
+Referenced by `pre_trade_briefs`.
+
+### Validation notes
+- minimum one checklist item
+- unique default checklist per user/account_type
+
+## 6) `pre_trade_briefs`
+### Purpose
+Immutable or versioned snapshot of a pre-entry plan.
+
+### Fields
+- `id: uuid` (PK)
+- `user_id: uuid` (FK users)
+- `pair_id: uuid` (FK forex_pairs)
+- `setup_id: uuid` (FK trade_setups)
+- `bias_report_id: uuid` (FK market_bias_reports)
+- `checklist_id: uuid` (FK execution_checklists)
+- `entry_plan: jsonb`
+- `risk_plan: jsonb`
+- `event_risk_summary: text`
+- `approval_state: text` (`ready|blocked|manual_override`)
+- `selected_event_ids: jsonb` (array UUIDs or provider IDs)
+- `created_at: timestamptz`
+- `updated_at: timestamptz`
+
+### Relationships
+Bridge between setup, bias, checklist, and eventual trade execution.
+
+### Validation notes
+- require entry + invalidation + stop + target in entry_plan
+- approval state blocked if mandatory checklist items incomplete
+
+## 7) `post_trade_reviews`
+### Purpose
+Structured reflection comparing actual execution vs pre-trade plan.
+
+### Fields
+- `id: uuid` (PK)
+- `user_id: uuid` (FK users)
+- `trade_id: uuid` (FK existing trades table)
+- `brief_id: uuid` (FK pre_trade_briefs)
+- `execution_grade: numeric` (0–100)
+- `rule_violations: jsonb`
+- `process_mistakes: jsonb`
+- `what_worked: text`
+- `improvements_next_trade: text`
+- `ai_summary: text`
+- `created_at: timestamptz`
+- `updated_at: timestamptz`
+
+### Relationships
+Anchored to historical trade record and optional pre-trade brief.
+
+### Validation notes
+- require at least one actionable improvement
+- execution grade range check

--- a/forex-agent/docs/execution-workflows.md
+++ b/forex-agent/docs/execution-workflows.md
@@ -1,0 +1,42 @@
+# Execution Workflows (Operational Draft)
+
+## 1) Pre-trade preparation workflow
+1. Select trading account and pair.
+2. Load latest pair context (session + recent volatility profile).
+3. Choose or create trade setup (`trade_setups`).
+4. Attach checklist template (`execution_checklists`).
+5. Confirm required checklist items (risk cap, max daily loss, rule compliance).
+6. Draft entry plan and risk plan.
+7. Save `pre_trade_brief` as `ready` or `blocked`.
+
+**Trader outcome:** clear plan quality gate before execution.
+
+## 2) Market bias generation workflow
+1. Trader selects pair + timeframe set.
+2. System gathers recent pair context and key levels.
+3. AI/manual analysis produces directional bias, assumptions, and invalidation.
+4. Confidence score is generated with rationale.
+5. Report saved to `market_bias_reports` and attached to open brief.
+6. If confidence low or invalidation unclear, brief remains blocked.
+
+**Trader outcome:** explicit bias context, not hidden intuition.
+
+## 3) Event-aware trade planning workflow
+1. Fetch upcoming events for pair currencies and session window.
+2. Highlight high-impact events near planned entry time.
+3. Generate event-risk summary: proceed / reduce size / wait.
+4. Trader updates risk_plan and approval_state accordingly.
+5. Persist selected event links in brief metadata.
+6. Re-check checklist item: “Event risk acknowledged.”
+
+**Trader outcome:** fewer avoidable trades taken into known volatility spikes.
+
+## 4) Post-trade review workflow
+1. Load completed trade and linked pre-trade brief.
+2. Compare actual execution details vs plan (entry, stop, exits, timing).
+3. Identify rule violations and process mistakes.
+4. AI generates structured summary with confidence-limited language.
+5. Trader confirms/edits findings and adds one concrete process improvement.
+6. Save `post_trade_review` and surface improvement in next pre-trade checklist.
+
+**Trader outcome:** tight feedback loop that improves future execution quality.

--- a/forex-agent/docs/integration-map.md
+++ b/forex-agent/docs/integration-map.md
@@ -1,0 +1,45 @@
+# Integration Map (Planned)
+
+This map links each Forex-agent capability to likely production targets in Tradia.
+
+## Capability: Pre-trade brief
+- Dashboard widgets: existing dashboard trade planning section (new card/module)
+- API endpoints: `app/api/forex-agent/pre-trade-brief/route.ts`
+- Shared lib utilities: `src/lib/forex-agent/brief-service.ts`, `src/lib/forex-agent/brief-validator.ts`
+- AI orchestration: `src/lib/forex-agent/ai/pre-trade-brief.ts`
+- Database tables: `trade_setups`, `execution_checklists`, `pre_trade_briefs`
+
+## Capability: Market bias report
+- Dashboard widgets: bias panel within pair/session analytics views
+- API endpoints: `app/api/forex-agent/market-bias/route.ts`
+- Shared lib utilities: `src/lib/forex-agent/bias-service.ts`, `src/lib/forex-agent/level-extractor.ts`
+- AI orchestration: `src/lib/forex-agent/ai/market-bias.ts`
+- Database tables: `market_bias_reports`, `forex_pairs`
+
+## Capability: Event-aware planning
+- Dashboard widgets: upcoming events card attached to trade plan flow
+- API endpoints: `app/api/forex-agent/economic-events/route.ts`
+- Shared lib utilities: `src/lib/forex-agent/event-service.ts`, `src/lib/forex-agent/event-normalizer.ts`
+- AI orchestration: optional event-risk summarizer module
+- Database tables: `economic_events`, `pre_trade_briefs`
+
+## Capability: Execution checklist support
+- Dashboard widgets: pre-submit checklist component near order/planning action
+- API endpoints: `app/api/forex-agent/execution-checklist/route.ts`
+- Shared lib utilities: `src/lib/forex-agent/checklist-service.ts`
+- AI orchestration: checklist rationale suggestions (optional, phase 4)
+- Database tables: `execution_checklists`, `pre_trade_briefs`
+
+## Capability: Post-trade review intelligence
+- Dashboard widgets: post-trade reflection panel on trade detail screen
+- API endpoints: `app/api/forex-agent/post-trade-review/route.ts`
+- Shared lib utilities: `src/lib/forex-agent/review-service.ts`, `src/lib/forex-agent/deviation-detector.ts`
+- AI orchestration: `src/lib/forex-agent/ai/post-trade-review.ts`
+- Database tables: `post_trade_reviews`, references to existing `trades` table
+
+## Capability: Cross-cutting guardrails and trust layer
+- Dashboard widgets: confidence indicators + disclaimer banners
+- API endpoints: shared middleware and response metadata
+- Shared lib utilities: `src/lib/forex-agent/safety-rules.ts`, `src/lib/forex-agent/confidence-policy.ts`
+- AI orchestration: response verifier and red-flag classifier
+- Database tables: optional `ai_audit_logs` (future), plus references in review tables

--- a/forex-agent/docs/phase-1-implementation-note.md
+++ b/forex-agent/docs/phase-1-implementation-note.md
@@ -1,0 +1,63 @@
+# Phase 1 Implementation Note — Pre-Trade Brief Vertical Slice
+
+## What was implemented
+A first production-ready, narrow slice for Forex Pre-Trade Briefs was added to Tradia with:
+
+1. **Database layer**
+   - New migration creating:
+     - `forex_pairs`
+     - `pre_trade_briefs`
+   - Includes indexes, seeded Forex pairs, and RLS policies.
+
+2. **Server-side generation flow**
+   - New AI service that generates structured, conservative pre-trade analysis sections:
+     - summary
+     - bias
+     - confluence
+     - risks
+     - invalidation signals
+     - checklist
+   - Includes risk-reward ratio helper and safety language constraints.
+
+3. **API endpoint**
+   - `GET /api/pre-trade-brief`
+     - fetch active Forex pairs
+     - fetch recent saved briefs for authenticated user
+   - `POST /api/pre-trade-brief`
+     - validates input
+     - validates optional price triplet consistency
+     - calculates risk-reward ratio
+     - generates AI brief
+     - stores and returns created row
+
+4. **Dashboard page**
+   - New route: `/dashboard/pre-trade-brief`
+   - Includes:
+     - pair selector
+     - timeframe/session/bias selectors
+     - setup notes
+     - optional entry/SL/TP fields
+     - submit/loading/error states
+     - generated result panel (all required sections)
+     - recent saved briefs list
+
+## Production files added/changed
+- `database/migrations/2026-04-09_create_forex_pre_trade_briefs.sql`
+- `src/types/preTradeBrief.ts`
+- `src/lib/forex/preTradeBriefService.ts`
+- `app/api/pre-trade-brief/route.ts`
+- `app/dashboard/pre-trade-brief/page.tsx`
+
+## What was intentionally left out
+- No live market data adapter integration.
+- No economic calendar ingestion pipeline.
+- No broker connectivity or automation.
+- No multi-step workflow/pages.
+- No notification system.
+- No dashboard-wide refactor.
+
+## Recommended next implementation step
+Implement brief detail retrieval and editing:
+- Add `GET /api/pre-trade-brief/[id]` and `PATCH /api/pre-trade-brief/[id]`.
+- Add a detail drawer/modal on `/dashboard/pre-trade-brief` to inspect and update setup notes/checklist status.
+- Add lightweight audit metadata (`model`, `prompt_version`, `generation_latency_ms`) to improve observability.

--- a/forex-agent/docs/phase-2-implementation-note.md
+++ b/forex-agent/docs/phase-2-implementation-note.md
@@ -1,0 +1,51 @@
+# Phase 2 Implementation Note — Saved Brief Detail + Light Editing
+
+## What was implemented
+This phase adds a narrow usability upgrade for the existing Forex Pre-Trade Brief flow:
+
+1. **Saved brief detail retrieval**
+   - Added per-brief API route to load full detail for one saved brief.
+   - Auth required and constrained to the signed-in user’s record.
+
+2. **Light editing support (no regeneration)**
+   - Added controlled patch API for:
+     - `status`
+     - `trader_notes`
+     - `checklist_state`
+     - `last_reviewed_at`
+   - Kept AI-generated analytical sections immutable through this endpoint.
+
+3. **Detail workflow UI on `/dashboard/pre-trade-brief`**
+   - Recent saved briefs are now selectable.
+   - Selecting an item loads full brief detail inline.
+   - Added editable trader workflow controls:
+     - trader notes textarea
+     - checklist progress toggles based on original AI checklist
+     - status selector (`draft`, `ready`, `invalidated`, `executed`, `skipped`)
+     - save action with loading/error handling
+
+4. **Type updates**
+   - Expanded `preTradeBrief` types for detail shape, checklist state map, and patch payload.
+
+## Files added or changed
+- **Added** `database/migrations/2026-04-09_add_pre_trade_brief_review_fields.sql`
+- **Added** `app/api/pre-trade-brief/[id]/route.ts`
+- **Updated** `app/api/pre-trade-brief/route.ts` (recent list now includes status)
+- **Updated** `src/types/preTradeBrief.ts`
+- **Updated** `app/dashboard/pre-trade-brief/page.tsx`
+
+## Migration added
+- `2026-04-09_add_pre_trade_brief_review_fields.sql`
+  - adds `trader_notes`, `checklist_state`, `last_reviewed_at`
+  - expands `status` check constraint to include editable workflow statuses
+  - preserves existing data and ownership policies
+
+## What was intentionally not included
+- No history/version timeline for edits.
+- No collaboration/comments.
+- No regeneration pipeline changes.
+- No market/event data integrations.
+- No additional pages or route tree expansion beyond the focused detail API route.
+
+## Recommended exact next implementation step
+Add a compact **brief detail read-only API response caching layer** (e.g., conditional GET/etag or lightweight memoized fetch on client) and then implement **brief status filtering** in the recent list (`all`, `ready`, `invalidated`, `executed`) to improve daily workflow speed without broadening scope.

--- a/forex-agent/docs/product-spec.md
+++ b/forex-agent/docs/product-spec.md
@@ -1,0 +1,43 @@
+# Product Spec — Forex Execution Intelligence (Internal)
+
+## Product definition
+Forex execution intelligence is a decision-support layer that sits around Tradia’s journaling core. It helps traders make better process decisions **before**, **during planning**, and **after** a trade by standardizing setup quality checks, risk framing, and review loops.
+
+## User problem
+Traders often know strategy concepts but execute inconsistently:
+- entering without a complete plan,
+- ignoring event risk,
+- changing bias mid-trade without explicit rationale,
+- repeating known mistakes due to weak feedback loops.
+
+A journal captures outcomes after the fact, but many avoidable losses happen because pre-trade and execution discipline are not operationalized.
+
+## Job-to-be-done
+“When I am preparing a Forex trade, help me quickly produce a high-quality, rule-safe plan with clear invalidation and event context, so I can execute consistently and improve over time.”
+
+## Target users
+1. Forex pair traders (session/timing-sensitive decision making)
+2. Prop firm traders (strict risk and rule compliance)
+3. Funded traders (capital preservation + consistency)
+
+## MVP scope
+### In scope
+- Structured pre-trade brief generation (manual + AI-assisted).
+- Market bias report (timeframe bias, levels, invalidation, confidence).
+- Event-aware planning support tied to upcoming economic events.
+- Execution checklist templates and completion tracking.
+- Post-trade review artifact comparing plan vs execution.
+- Internal data models and API contracts for eventual dashboard integration.
+
+### Out of scope (explicit)
+- Automated trade execution or broker-side order placement.
+- “Signal service” positioning or certainty claims.
+- Full dashboard redesign.
+- New public marketing surface.
+- Non-Forex multi-asset expansion (crypto/equities) in first phase.
+
+## Success criteria (MVP)
+- Traders can complete a pre-trade brief in <5 minutes with consistent structure.
+- Event risk is visible before confirmation of a trade plan.
+- Post-trade review can link deviations to actionable process changes.
+- AI outputs remain advisory, transparent, and overrideable.

--- a/forex-agent/prompts/market-bias.prompt.md
+++ b/forex-agent/prompts/market-bias.prompt.md
@@ -1,0 +1,43 @@
+# Prompt Design — Market Bias
+
+## Purpose
+Produce an explicit directional bias report with assumptions, key levels, and invalidation logic.
+
+## Required inputs
+- pair symbol
+- multi-timeframe summaries
+- key level candidates
+- session context
+- recent event backdrop
+
+## Expected output shape
+```json
+{
+  "bias_direction": "bullish|bearish|neutral",
+  "timeframe_alignment": {
+    "higher_tf": "string",
+    "execution_tf": "string"
+  },
+  "key_levels": {
+    "support": ["number"],
+    "resistance": ["number"],
+    "invalidation_level": "number"
+  },
+  "assumptions": ["string"],
+  "invalidation_conditions": ["string"],
+  "alternate_scenario": "string",
+  "confidence": "number_0_to_100",
+  "confidence_rationale": "string"
+}
+```
+
+## Guardrails
+- Do not output “take this trade” directives.
+- Must include alternate scenario and invalidation conditions.
+- Confidence must decrease when inputs conflict.
+- State uncertainty explicitly when timeframes disagree.
+
+## Example output (short)
+- `bias_direction`: `neutral`
+- `alternate_scenario`: “Bullish bias valid only on sustained hold above 1.0860.”
+- `confidence`: `52`

--- a/forex-agent/prompts/post-trade-review.prompt.md
+++ b/forex-agent/prompts/post-trade-review.prompt.md
@@ -1,0 +1,35 @@
+# Prompt Design — Post-Trade Review
+
+## Purpose
+Generate a process-focused review by comparing planned setup/brief against actual execution behavior.
+
+## Required inputs
+- trade execution record
+- linked pre-trade brief (if available)
+- checklist completion state
+- user notes/emotional tags (optional)
+
+## Expected output shape
+```json
+{
+  "plan_vs_execution_diff": ["string"],
+  "rule_violations": ["string"],
+  "process_mistakes": ["string"],
+  "what_worked": ["string"],
+  "top_3_improvements": ["string"],
+  "next_trade_focus": "string",
+  "confidence": "number_0_to_100",
+  "confidence_rationale": "string"
+}
+```
+
+## Guardrails
+- No blame language; focus on process and behavior.
+- No outcome-only reasoning (“won = good process”).
+- Require at least one actionable improvement.
+- If no brief exists, annotate reduced confidence and explain limitations.
+
+## Example output (short)
+- `plan_vs_execution_diff`: ["Entry taken before planned confirmation candle close."]
+- `top_3_improvements`: ["Wait for candle close confirmation", "Pre-place stop before entry", "Avoid entries inside 10 minutes pre-news"]
+- `confidence`: `71`

--- a/forex-agent/prompts/pre-trade-brief.prompt.md
+++ b/forex-agent/prompts/pre-trade-brief.prompt.md
@@ -1,0 +1,47 @@
+# Prompt Design — Pre-Trade Brief
+
+## Purpose
+Generate a structured pre-trade brief that helps the trader validate setup quality, risk, and event context before execution.
+
+## Required inputs
+- pair and timeframe context
+- setup definition + confluence factors
+- risk constraints (account type, max loss rules)
+- relevant upcoming economic events
+- checklist status
+
+## Expected output shape
+```json
+{
+  "market_context": "string",
+  "setup_summary": "string",
+  "entry_plan": {
+    "entry_type": "market|limit|stop",
+    "entry_zone": "string",
+    "stop_loss": "string",
+    "targets": ["string"],
+    "invalidation": "string"
+  },
+  "risk_plan": {
+    "risk_percent": "number",
+    "position_sizing_note": "string",
+    "rule_constraints": ["string"]
+  },
+  "event_risk_summary": "string",
+  "checklist_findings": ["string"],
+  "approval_recommendation": "ready|blocked|manual_override",
+  "confidence": "number_0_to_100",
+  "confidence_rationale": "string"
+}
+```
+
+## Guardrails
+- Never claim certainty of trade outcome.
+- Must include invalidation statement.
+- If data is incomplete, set `approval_recommendation=blocked` and list missing inputs.
+- Keep language advisory, not imperative.
+
+## Example output (short)
+- `market_context`: “EURUSD in London session shows higher-timeframe bullish structure with intraday pullback.”
+- `approval_recommendation`: `manual_override`
+- `confidence`: `63`

--- a/forex-agent/research/ai-trader-notes.md
+++ b/forex-agent/research/ai-trader-notes.md
@@ -1,0 +1,38 @@
+# AI-Trader Study Notes (Practical)
+
+## Why this note exists
+Capture useful workflow ideas inspired by AI-Trader-style systems without copying implementation or product identity.
+
+## Useful ideas to learn from
+1. **Lifecycle decomposition**
+   - Split analysis into pre-trade, in-trade context, and post-trade review stages.
+   - Benefit: improves prompt focus and output consistency.
+
+2. **Structured artifacts over free chat**
+   - Force outputs into stable schemas (brief, bias report, review object).
+   - Benefit: easier validation, persistence, and UI rendering.
+
+3. **State transitions and gating**
+   - Use explicit statuses (`draft`, `ready`, `blocked`, `reviewed`).
+   - Benefit: process discipline and clearer audit trail.
+
+4. **Checklist-linked reasoning**
+   - Tie model output to trader checklist and account constraints.
+   - Benefit: higher practical utility for prop/funded contexts.
+
+5. **Plan-vs-execution diffing**
+   - Compare intent and action explicitly, then produce improvements.
+   - Benefit: creates a repeatable learning loop.
+
+## What should NOT be copied
+- Any branding, UI identity, or product naming patterns.
+- Any repo architecture that conflicts with Tradia’s Next.js + Supabase conventions.
+- “Black-box signal” framing or certainty language.
+- Any design that bypasses user control and accountability.
+- Generic multi-asset abstraction that weakens Forex-first usability.
+
+## Adaptation principles for Tradia
+- Keep Forex and prop-firm constraints first-class.
+- Reuse existing Tradia auth, data ownership, and dashboard mental model.
+- Keep AI advisory and transparent; show assumptions/invalidation always.
+- Implement in small slices that can ship independently.

--- a/forex-agent/schemas/economic-event.schema.ts
+++ b/forex-agent/schemas/economic-event.schema.ts
@@ -1,0 +1,30 @@
+/**
+ * Draft schema artifact for economic_events.
+ */
+
+export type EventImpact = 'low' | 'medium' | 'high';
+
+export type EconomicEvent = {
+  id: string;
+  providerEventId?: string;
+  title: string;
+  country: string;
+  currency: string;
+  impact: EventImpact;
+  scheduledAt: string;
+  actual?: string;
+  forecast?: string;
+  previous?: string;
+  eventType: string;
+  isAllDay: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const validateEconomicEventDraft = (event: EconomicEvent): string[] => {
+  const errors: string[] = [];
+  if (!event.title.trim()) errors.push('title is required');
+  if (!/^[A-Z]{3}$/.test(event.currency)) errors.push('currency must be 3 uppercase letters');
+  if (!event.scheduledAt) errors.push('scheduledAt is required');
+  return errors;
+};

--- a/forex-agent/schemas/execution-checklist.schema.ts
+++ b/forex-agent/schemas/execution-checklist.schema.ts
@@ -1,0 +1,31 @@
+/**
+ * Draft schema artifact for execution_checklists.
+ */
+
+export type AccountType = 'personal' | 'prop' | 'funded';
+
+export type ChecklistItem = {
+  id: string;
+  label: string;
+  required: boolean;
+  category: 'risk' | 'setup' | 'event' | 'discipline';
+};
+
+export type ExecutionChecklist = {
+  id: string;
+  userId: string;
+  name: string;
+  accountType: AccountType;
+  items: ChecklistItem[];
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const validateExecutionChecklistDraft = (checklist: ExecutionChecklist): string[] => {
+  const errors: string[] = [];
+  if (!checklist.name.trim()) errors.push('name is required');
+  if (checklist.items.length === 0) errors.push('at least one checklist item is required');
+  if (checklist.items.some((item) => !item.label.trim())) errors.push('all checklist items need labels');
+  return errors;
+};

--- a/forex-agent/schemas/forex-pairs.schema.ts
+++ b/forex-agent/schemas/forex-pairs.schema.ts
@@ -1,0 +1,30 @@
+/**
+ * Draft schema artifact for forex_pairs.
+ * Planning-only; not wired into production runtime.
+ */
+
+export type SessionProfile = {
+  activeSessions: Array<'ASIA' | 'LONDON' | 'NEW_YORK' | 'OVERLAP'>;
+  volatilityNote?: string;
+};
+
+export type ForexPair = {
+  id: string;
+  symbol: string; // e.g., EURUSD
+  baseCurrency: string; // ISO-4217 (3-char)
+  quoteCurrency: string; // ISO-4217 (3-char)
+  pipPrecision: number;
+  sessionProfile: SessionProfile;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const validateForexPairDraft = (pair: ForexPair): string[] => {
+  const errors: string[] = [];
+  if (!/^[A-Z]{6}$/.test(pair.symbol)) errors.push('symbol must be 6 uppercase letters');
+  if (!/^[A-Z]{3}$/.test(pair.baseCurrency)) errors.push('baseCurrency must be 3 uppercase letters');
+  if (!/^[A-Z]{3}$/.test(pair.quoteCurrency)) errors.push('quoteCurrency must be 3 uppercase letters');
+  if (pair.pipPrecision <= 0) errors.push('pipPrecision must be > 0');
+  return errors;
+};

--- a/forex-agent/schemas/market-bias-report.schema.ts
+++ b/forex-agent/schemas/market-bias-report.schema.ts
@@ -1,0 +1,39 @@
+/**
+ * Draft schema artifact for market_bias_reports.
+ */
+
+export type BiasDirection = 'bullish' | 'bearish' | 'neutral';
+export type BiasSource = 'manual' | 'ai' | 'hybrid';
+
+export type MarketBiasReport = {
+  id: string;
+  userId: string;
+  pairId: string;
+  timeframeSet: string[]; // e.g., ['H4', 'H1', 'M15']
+  biasDirection: BiasDirection;
+  confidenceScore: number; // 0-100
+  keyLevels: {
+    support?: number[];
+    resistance?: number[];
+    invalidationLevel?: number;
+  };
+  assumptions: string;
+  invalidationConditions: string;
+  source: BiasSource;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const validateMarketBiasReportDraft = (report: MarketBiasReport): string[] => {
+  const errors: string[] = [];
+  if (report.confidenceScore < 0 || report.confidenceScore > 100) {
+    errors.push('confidenceScore must be between 0 and 100');
+  }
+  if (!report.invalidationConditions.trim()) {
+    errors.push('invalidationConditions is required');
+  }
+  if (!report.timeframeSet.length) {
+    errors.push('timeframeSet must contain at least one timeframe');
+  }
+  return errors;
+};

--- a/forex-agent/schemas/post-trade-review.schema.ts
+++ b/forex-agent/schemas/post-trade-review.schema.ts
@@ -1,0 +1,32 @@
+/**
+ * Draft schema artifact for post_trade_reviews.
+ */
+
+export type PostTradeReview = {
+  id: string;
+  userId: string;
+  tradeId: string;
+  briefId?: string;
+  executionGrade: number; // 0-100
+  ruleViolations: string[];
+  processMistakes: string[];
+  whatWorked: string;
+  improvementsNextTrade: string[];
+  aiSummary?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const validatePostTradeReviewDraft = (review: PostTradeReview): string[] => {
+  const errors: string[] = [];
+  if (review.executionGrade < 0 || review.executionGrade > 100) {
+    errors.push('executionGrade must be between 0 and 100');
+  }
+  if (review.improvementsNextTrade.length === 0) {
+    errors.push('at least one improvement is required');
+  }
+  if (!review.whatWorked.trim()) {
+    errors.push('whatWorked is required');
+  }
+  return errors;
+};

--- a/forex-agent/schemas/pre-trade-brief.schema.ts
+++ b/forex-agent/schemas/pre-trade-brief.schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Draft schema artifact for pre_trade_briefs.
+ */
+
+export type ApprovalState = 'ready' | 'blocked' | 'manual_override';
+
+export type PreTradeBrief = {
+  id: string;
+  userId: string;
+  pairId: string;
+  setupId: string;
+  biasReportId: string;
+  checklistId: string;
+  entryPlan: {
+    entryType: 'market' | 'limit' | 'stop';
+    entryPrice?: number;
+    stopLoss: number;
+    takeProfit: number[];
+    invalidation: string;
+  };
+  riskPlan: {
+    riskPercent: number;
+    maxDailyLossPercent: number;
+    accountRuleNotes?: string;
+  };
+  eventRiskSummary: string;
+  approvalState: ApprovalState;
+  selectedEventIds: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const validatePreTradeBriefDraft = (brief: PreTradeBrief): string[] => {
+  const errors: string[] = [];
+  if (!brief.entryPlan.invalidation.trim()) errors.push('entryPlan.invalidation is required');
+  if (brief.riskPlan.riskPercent <= 0) errors.push('riskPercent must be > 0');
+  if (brief.riskPlan.maxDailyLossPercent <= 0) errors.push('maxDailyLossPercent must be > 0');
+  if (!brief.eventRiskSummary.trim()) errors.push('eventRiskSummary is required');
+  return errors;
+};

--- a/forex-agent/schemas/trade-setup.schema.ts
+++ b/forex-agent/schemas/trade-setup.schema.ts
@@ -1,0 +1,28 @@
+/**
+ * Draft schema artifact for trade_setups.
+ */
+
+export type SetupStatus = 'draft' | 'ready' | 'invalidated' | 'executed';
+
+export type TradeSetup = {
+  id: string;
+  userId: string;
+  pairId: string;
+  setupName: string;
+  setupType: 'breakout' | 'pullback' | 'reversal' | 'range' | 'news_reaction' | 'other';
+  timeframe: string;
+  session: 'ASIA' | 'LONDON' | 'NEW_YORK' | 'OVERLAP';
+  confluenceFactors: string[];
+  qualityScore: number; // 0-100
+  status: SetupStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const validateTradeSetupDraft = (setup: TradeSetup): string[] => {
+  const errors: string[] = [];
+  if (setup.setupName.trim().length < 3) errors.push('setupName must be at least 3 chars');
+  if (setup.qualityScore < 0 || setup.qualityScore > 100) errors.push('qualityScore must be 0-100');
+  if (!setup.confluenceFactors.length) errors.push('at least one confluence factor is required');
+  return errors;
+};

--- a/src/lib/forex/preTradeBriefService.ts
+++ b/src/lib/forex/preTradeBriefService.ts
@@ -1,0 +1,154 @@
+import { mistral } from "@ai-sdk/mistral";
+import { generateText } from "ai";
+import type { GeneratedPreTradeBrief, PreTradeBriefInput } from "@/types/preTradeBrief";
+
+const SAFETY_DISCLAIMER =
+  "This analysis is decision-support only, not financial advice, and does not guarantee outcomes.";
+
+const cleanText = (value: string): string => {
+  const blockedPhrases = [
+    /guaranteed?/gi,
+    /certain(ty)?/gi,
+    /can't lose/gi,
+    /must win/gi,
+    /take this trade now/gi,
+  ];
+
+  let output = value;
+  blockedPhrases.forEach((pattern) => {
+    output = output.replace(pattern, "high-confidence");
+  });
+
+  return output.trim();
+};
+
+const toStringArray = (value: unknown, fallback: string[]): string[] => {
+  if (!Array.isArray(value)) return fallback;
+  const normalized = value
+    .map((item) => String(item ?? "").trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  return normalized.length ? normalized : fallback;
+};
+
+const fallbackBrief = (input: PreTradeBriefInput): GeneratedPreTradeBrief => ({
+  summary: cleanText(
+    `${input.pairSymbol} ${input.timeframe} plan captured with ${input.marketSession} session context and ${input.directionalBiasInput} directional idea. ${SAFETY_DISCLAIMER}`
+  ),
+  bias: cleanText(
+    `${input.directionalBiasInput.toUpperCase()} bias is user-provided and should be confirmed against structure, session behavior, and risk rules.`
+  ),
+  confluence: [
+    "Confirm higher timeframe structure alignment.",
+    "Check session volatility behavior before execution.",
+    "Ensure entry plan aligns with invalidation level.",
+  ],
+  risks: [
+    "Directional view may fail if market structure shifts.",
+    "Session volatility spikes can invalidate planned entries.",
+    "Unexpected macro headlines can reduce setup reliability.",
+  ],
+  invalidationSignals: [
+    "Price closes beyond planned invalidation zone.",
+    "Momentum fails to confirm the planned direction.",
+    "Risk parameters no longer fit account rules.",
+  ],
+  checklist: [
+    "Position size respects account risk limit.",
+    "Entry, stop-loss, and take-profit are defined before execution.",
+    "No certainty assumptions; scenario-based execution only.",
+  ],
+});
+
+const parseModelOutput = (rawText: string, input: PreTradeBriefInput): GeneratedPreTradeBrief => {
+  try {
+    const parsed = JSON.parse(rawText);
+
+    return {
+      summary: cleanText(String(parsed.summary || "")) || fallbackBrief(input).summary,
+      bias: cleanText(String(parsed.bias || "")) || fallbackBrief(input).bias,
+      confluence: toStringArray(parsed.confluence, fallbackBrief(input).confluence),
+      risks: toStringArray(parsed.risks, fallbackBrief(input).risks),
+      invalidationSignals: toStringArray(parsed.invalidationSignals, fallbackBrief(input).invalidationSignals),
+      checklist: toStringArray(parsed.checklist, fallbackBrief(input).checklist),
+    };
+  } catch {
+    return fallbackBrief(input);
+  }
+};
+
+export async function generatePreTradeBrief(input: PreTradeBriefInput): Promise<GeneratedPreTradeBrief> {
+  const prompt = `You are Tradia's Forex pre-trade analysis assistant.
+
+Task:
+Return only valid JSON with this exact shape:
+{
+  "summary": "string",
+  "bias": "string",
+  "confluence": ["string"],
+  "risks": ["string"],
+  "invalidationSignals": ["string"],
+  "checklist": ["string"]
+}
+
+Safety rules:
+- Decision-support only, never certainty.
+- Never promise profits.
+- Never use directives like \"take this trade now\".
+- Keep language conservative and risk-aware.
+- Mention uncertainty where relevant.
+
+Context:
+- Pair: ${input.pairSymbol}
+- Timeframe: ${input.timeframe}
+- Session: ${input.marketSession}
+- Directional bias input: ${input.directionalBiasInput}
+- Setup notes: ${input.setupNotes || "N/A"}
+- Planned entry: ${input.plannedEntry ?? "N/A"}
+- Planned stop loss: ${input.plannedStopLoss ?? "N/A"}
+- Planned take profit: ${input.plannedTakeProfit ?? "N/A"}`;
+
+  try {
+    const result = await generateText({
+      model: mistral("mistral-large-latest") as any,
+      prompt,
+      temperature: 0.2,
+      maxTokens: 500,
+    });
+
+    const parsed = parseModelOutput(result.text, input);
+
+    return {
+      ...parsed,
+      summary: `${parsed.summary} ${SAFETY_DISCLAIMER}`.trim(),
+    };
+  } catch (error) {
+    console.error("Pre-trade brief AI generation failed:", error);
+    return fallbackBrief(input);
+  }
+}
+
+export function calculateRiskReward(
+  plannedEntry?: number | null,
+  plannedStopLoss?: number | null,
+  plannedTakeProfit?: number | null
+): number | null {
+  if (
+    plannedEntry == null ||
+    plannedStopLoss == null ||
+    plannedTakeProfit == null ||
+    !Number.isFinite(plannedEntry) ||
+    !Number.isFinite(plannedStopLoss) ||
+    !Number.isFinite(plannedTakeProfit)
+  ) {
+    return null;
+  }
+
+  const risk = Math.abs(plannedEntry - plannedStopLoss);
+  if (risk === 0) return null;
+
+  const reward = Math.abs(plannedTakeProfit - plannedEntry);
+  if (reward === 0) return null;
+
+  return Math.round((reward / risk) * 100) / 100;
+}

--- a/src/types/preTradeBrief.ts
+++ b/src/types/preTradeBrief.ts
@@ -1,0 +1,80 @@
+export type MarketSession = "ASIA" | "LONDON" | "NEW_YORK" | "OVERLAP";
+export type DirectionalBias = "bullish" | "bearish" | "neutral";
+
+export type EditablePreTradeBriefStatus = "draft" | "ready" | "invalidated" | "executed" | "skipped";
+export type PreTradeBriefStatus = "generated" | "failed" | EditablePreTradeBriefStatus;
+
+export interface PreTradeBriefInput {
+  pairSymbol: string;
+  timeframe: string;
+  marketSession: MarketSession;
+  directionalBiasInput: DirectionalBias;
+  setupNotes?: string;
+  plannedEntry?: number | null;
+  plannedStopLoss?: number | null;
+  plannedTakeProfit?: number | null;
+}
+
+export interface GeneratedPreTradeBrief {
+  summary: string;
+  bias: string;
+  confluence: string[];
+  risks: string[];
+  invalidationSignals: string[];
+  checklist: string[];
+}
+
+export interface ChecklistItemState {
+  completed: boolean;
+  completedAt?: string;
+}
+
+export type ChecklistStateMap = Record<string, ChecklistItemState>;
+
+export interface PreTradeBriefRecord {
+  id: string;
+  user_id: string;
+  forex_pair_id: string;
+  pair_symbol_snapshot: string;
+  timeframe: string;
+  market_session: MarketSession;
+  directional_bias_input: DirectionalBias;
+  setup_notes: string | null;
+  planned_entry: number | null;
+  planned_stop_loss: number | null;
+  planned_take_profit: number | null;
+  risk_reward_ratio: number | null;
+  ai_summary: string | null;
+  ai_bias: string | null;
+  ai_confluence: string[];
+  ai_risks: string[];
+  ai_invalidators: string[];
+  ai_checklist: string[];
+  raw_ai_response: unknown;
+  trader_notes?: string | null;
+  checklist_state?: ChecklistStateMap | null;
+  last_reviewed_at?: string | null;
+  status: PreTradeBriefStatus;
+  created_at: string;
+  updated_at: string;
+  forex_pairs?: {
+    symbol: string;
+  } | null;
+}
+
+export interface PreTradeBriefListItem {
+  id: string;
+  pair_symbol_snapshot: string;
+  timeframe: string;
+  market_session: MarketSession;
+  directional_bias_input: DirectionalBias;
+  status: PreTradeBriefStatus;
+  created_at: string;
+}
+
+export interface UpdatePreTradeBriefPayload {
+  status?: EditablePreTradeBriefStatus;
+  trader_notes?: string | null;
+  checklist_state?: ChecklistStateMap | null;
+  last_reviewed_at?: string | null;
+}


### PR DESCRIPTION
## Summary
Implemented the next narrow production slice for Forex Pre-Trade Briefs: **saved brief detail and light editing**.

## What was added

### 1) Follow-up migration
- `database/migrations/2026-04-09_add_pre_trade_brief_review_fields.sql`
  - adds nullable fields to `pre_trade_briefs`:
    - `trader_notes`
    - `checklist_state` (jsonb)
    - `last_reviewed_at`
  - expands status check constraint to support workflow statuses:
    - `draft`, `ready`, `invalidated`, `executed`, `skipped`
  - preserves existing data model and ownership policy behavior

### 2) Detail API route
- `app/api/pre-trade-brief/[id]/route.ts`
  - `GET`:
    - auth required
    - returns one full brief for the signed-in user only
  - `PATCH`:
    - auth required
    - supports only controlled fields:
      - `status`
      - `trader_notes`
      - `checklist_state`
      - `last_reviewed_at`
    - validates payload shape
    - blocks unsafe mutation of AI analytical content and ownership fields

### 3) Main list API update
- `app/api/pre-trade-brief/route.ts`
  - recent briefs list now returns `status` for the selectable list UI

### 4) Type updates
- `src/types/preTradeBrief.ts`
  - added explicit status unions (`PreTradeBriefStatus`, editable statuses)
  - added `ChecklistItemState` / `ChecklistStateMap`
  - added update payload type
  - extended record and list item typing for detail/edit flow

### 5) Dashboard page UX upgrade
- `app/dashboard/pre-trade-brief/page.tsx`
  - recent briefs are now selectable
  - selecting a brief loads full detail via `/api/pre-trade-brief/[id]`
  - inline detail panel shows:
    - pair, timeframe, session, directional idea
    - setup notes, entry/SL/TP, R:R, created date, status
    - full AI sections (summary, bias, confluence, risks, invalidation, checklist)
  - editable workflow controls added:
    - trader notes textarea
    - checklist completion tracking (stored in `checklist_state`)
    - status selector (draft/ready/invalidated/executed/skipped)
    - save action with loading/error states
  - no full-page navigation needed for detail inspection

### 6) Documentation
- `forex-agent/docs/phase-2-implementation-note.md`
  - summarizes implementation scope, file changes, migration, exclusions, and next step

## Scope boundaries respected
- no regeneration history
- no collaboration/comments
- no market data/event feed expansion
- no websocket/live update systems
- no unrelated architectural refactors

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73d2eaa4483298bbb176694c21178)