### PR TITLE
[codex] fix oauth callback host and harden sql migration replay

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,47 @@
 // src/app/api/auth/[...nextauth]/route.ts
 import NextAuth from "next-auth";
+import type { NextRequest } from "next/server";
 import { authOptions } from "@/lib/authOptions";
 
-const handler = NextAuth(authOptions);
+const nextAuthHandler = NextAuth(authOptions);
+
+const PROD_FALLBACK_HOST = "tradiaai.app";
+
+const resolveRequestBase = (request: NextRequest): string | null => {
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  const host = forwardedHost || request.headers.get("host");
+  if (!host) return null;
+
+  const cleanHost = host.trim().toLowerCase();
+  if (!cleanHost) return null;
+
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  const protocol = forwardedProto || (cleanHost.includes("localhost") ? "http" : "https");
+
+  return `${protocol}://${cleanHost}`;
+};
+
+const applySafeNextAuthUrl = (request: NextRequest) => {
+  const requestBase = resolveRequestBase(request);
+  const isProd = process.env.NODE_ENV === "production";
+
+  if (isProd) {
+    if (requestBase && !requestBase.includes("localhost")) {
+      process.env.NEXTAUTH_URL = requestBase;
+      return;
+    }
+    process.env.NEXTAUTH_URL = `https://${PROD_FALLBACK_HOST}`;
+    return;
+  }
+
+  if (requestBase) {
+    process.env.NEXTAUTH_URL = requestBase;
+  }
+};
+
+const handler = async (request: NextRequest, context: unknown) => {
+  applySafeNextAuthUrl(request);
+  return nextAuthHandler(request, context as any);
+};
+
 export { handler as GET, handler as POST };

--- a/app/api/market-bias/route.ts
+++ b/app/api/market-bias/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/authOptions";
+import { createClient } from "@/utils/supabase/server";
+import { generateMarketBias } from "@/lib/forex/marketBiasService";
+import type { MarketBiasInput } from "@/types/marketBias";
+
+export const dynamic = "force-dynamic";
+
+const VALID_TIMEFRAMES = ["M5", "M15", "M30", "H1", "H4", "D1"] as const;
+
+const normalizeTimeframeSet = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+
+  const normalized = value
+    .map((item) => String(item ?? "").trim().toUpperCase())
+    .filter((item) => VALID_TIMEFRAMES.includes(item as (typeof VALID_TIMEFRAMES)[number]));
+
+  return Array.from(new Set(normalized)).slice(0, 6);
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const pairFilter = request.nextUrl.searchParams.get("pairSymbol")?.trim().toUpperCase();
+    const supabase = createClient();
+
+    let query = supabase
+      .from("market_bias_reports")
+      .select(
+        "id, pair_symbol_snapshot, timeframe_set, bias_direction, confidence_score, key_levels, assumptions, invalidation_conditions, alternate_scenario, confidence_rationale, source, created_at"
+      )
+      .eq("user_id", session.user.id)
+      .order("created_at", { ascending: false })
+      .limit(10);
+
+    if (pairFilter) {
+      query = query.eq("pair_symbol_snapshot", pairFilter);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ reports: data || [] });
+  } catch (error) {
+    console.error("GET /api/market-bias failed:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return NextResponse.json({ error: "Invalid request payload" }, { status: 400 });
+    }
+
+    const pairSymbol = String(body.pairSymbol || "").trim().toUpperCase();
+    const timeframeSet = normalizeTimeframeSet(body.timeframeSet);
+    const sessionContext = body.sessionContext ? String(body.sessionContext).trim() : "";
+    const recentBackdrop = body.recentBackdrop ? String(body.recentBackdrop).trim() : "";
+
+    if (!pairSymbol) {
+      return NextResponse.json({ error: "pairSymbol is required" }, { status: 400 });
+    }
+    if (!timeframeSet.length) {
+      return NextResponse.json({ error: "At least one valid timeframe is required" }, { status: 400 });
+    }
+
+    const supabase = createClient();
+
+    const { data: pairData, error: pairError } = await supabase
+      .from("forex_pairs")
+      .select("id, symbol")
+      .eq("symbol", pairSymbol)
+      .eq("is_active", true)
+      .single();
+
+    if (pairError || !pairData) {
+      return NextResponse.json({ error: "Selected forex pair is not available" }, { status: 400 });
+    }
+
+    const input: MarketBiasInput = {
+      pairSymbol,
+      timeframeSet,
+      sessionContext,
+      recentBackdrop,
+    };
+
+    const generated = await generateMarketBias(input);
+
+    const { data: created, error: createError } = await supabase
+      .from("market_bias_reports")
+      .insert([
+        {
+          user_id: session.user.id,
+          forex_pair_id: pairData.id,
+          pair_symbol_snapshot: pairData.symbol,
+          timeframe_set: timeframeSet,
+          bias_direction: generated.biasDirection,
+          confidence_score: generated.confidenceScore,
+          key_levels: generated.keyLevels,
+          assumptions: generated.assumptions,
+          invalidation_conditions: generated.invalidationConditions,
+          alternate_scenario: generated.alternateScenario,
+          confidence_rationale: generated.confidenceRationale,
+          source: "ai",
+          raw_ai_response: generated,
+        },
+      ])
+      .select(
+        "id, pair_symbol_snapshot, timeframe_set, bias_direction, confidence_score, key_levels, assumptions, invalidation_conditions, alternate_scenario, confidence_rationale, source, created_at"
+      )
+      .single();
+
+    if (createError || !created) {
+      return NextResponse.json({ error: createError?.message || "Failed to save market bias report" }, { status: 500 });
+    }
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/market-bias failed:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/pre-trade-brief/route.ts
+++ b/app/api/pre-trade-brief/route.ts
@@ -10,6 +10,15 @@ export const dynamic = "force-dynamic";
 const VALID_SESSIONS: MarketSession[] = ["ASIA", "LONDON", "NEW_YORK", "OVERLAP"];
 const VALID_BIAS: DirectionalBias[] = ["bullish", "bearish", "neutral"];
 const VALID_TIMEFRAMES = ["M5", "M15", "M30", "H1", "H4", "D1"] as const;
+const FILTERABLE_STATUSES = [
+  "generated",
+  "draft",
+  "ready",
+  "invalidated",
+  "executed",
+  "skipped",
+  "failed",
+] as const;
 
 const isValidNumber = (value: unknown): value is number =>
   typeof value === "number" && Number.isFinite(value);
@@ -20,14 +29,34 @@ const normalizeOptionalNumber = (value: unknown): number | null => {
   return Number.isFinite(parsed) ? parsed : null;
 };
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const statusFilterRaw = request.nextUrl.searchParams.get("status");
+    const statusFilter = statusFilterRaw ? statusFilterRaw.trim().toLowerCase() : "all";
+
+    if (
+      statusFilter !== "all" &&
+      !FILTERABLE_STATUSES.includes(statusFilter as (typeof FILTERABLE_STATUSES)[number])
+    ) {
+      return NextResponse.json({ error: "status filter is invalid" }, { status: 400 });
+    }
+
     const supabase = createClient();
+    let briefsQuery = supabase
+      .from("pre_trade_briefs")
+      .select("id, pair_symbol_snapshot, timeframe, market_session, directional_bias_input, status, created_at")
+      .eq("user_id", session.user.id)
+      .order("created_at", { ascending: false })
+      .limit(10);
+
+    if (statusFilter !== "all") {
+      briefsQuery = briefsQuery.eq("status", statusFilter);
+    }
 
     const [pairsResult, briefsResult] = await Promise.all([
       supabase
@@ -35,12 +64,7 @@ export async function GET() {
         .select("id, symbol, base_currency, quote_currency, category")
         .eq("is_active", true)
         .order("symbol", { ascending: true }),
-      supabase
-        .from("pre_trade_briefs")
-        .select("id, pair_symbol_snapshot, timeframe, market_session, directional_bias_input, status, created_at")
-        .eq("user_id", session.user.id)
-        .order("created_at", { ascending: false })
-        .limit(10),
+      briefsQuery,
     ]);
 
     if (pairsResult.error) {

--- a/app/dashboard/pre-trade-brief/page.tsx
+++ b/app/dashboard/pre-trade-brief/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import LayoutClient from "@/components/LayoutClient";
@@ -12,6 +12,7 @@ import type {
   PreTradeBriefListItem,
   PreTradeBriefRecord,
 } from "@/types/preTradeBrief";
+import type { MarketBiasRecord } from "@/types/marketBias";
 
 type PairOption = {
   id: string;
@@ -41,6 +42,9 @@ const TIMEFRAMES = ["M5", "M15", "M30", "H1", "H4", "D1"];
 const SESSIONS = ["ASIA", "LONDON", "NEW_YORK", "OVERLAP"];
 const BIASES = ["bullish", "bearish", "neutral"];
 const EDITABLE_STATUSES: EditablePreTradeBriefStatus[] = ["draft", "ready", "invalidated", "executed", "skipped"];
+const BRIEF_STATUS_FILTERS = ["all", "ready", "invalidated", "executed"] as const;
+type BriefStatusFilter = (typeof BRIEF_STATUS_FILTERS)[number];
+const BIAS_TIMEFRAMES = ["M15", "M30", "H1", "H4", "D1"] as const;
 
 const formatDate = (iso: string) => {
   try {
@@ -64,6 +68,7 @@ function PreTradeBriefContent() {
 
   const [selectedBriefId, setSelectedBriefId] = useState<string | null>(null);
   const [selectedBrief, setSelectedBrief] = useState<PreTradeBriefRecord | null>(null);
+  const detailCacheRef = useRef<Record<string, PreTradeBriefRecord>>({});
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
 
@@ -80,6 +85,14 @@ function PreTradeBriefContent() {
   const [plannedEntry, setPlannedEntry] = useState("");
   const [plannedStopLoss, setPlannedStopLoss] = useState("");
   const [plannedTakeProfit, setPlannedTakeProfit] = useState("");
+  const [briefStatusFilter, setBriefStatusFilter] = useState<BriefStatusFilter>("all");
+
+  const [biasTimeframes, setBiasTimeframes] = useState<string[]>(["H4", "H1", "M15"]);
+  const [biasSessionContext, setBiasSessionContext] = useState("");
+  const [biasBackdrop, setBiasBackdrop] = useState("");
+  const [generatingBias, setGeneratingBias] = useState(false);
+  const [biasError, setBiasError] = useState<string | null>(null);
+  const [latestBias, setLatestBias] = useState<MarketBiasRecord | null>(null);
 
   const canSubmit = useMemo(() => {
     return Boolean(pairSymbol && timeframe && marketSession && directionalBiasInput);
@@ -90,7 +103,7 @@ function PreTradeBriefContent() {
     setGlobalError(null);
 
     try {
-      const response = await fetch("/api/pre-trade-brief", { method: "GET" });
+      const response = await fetch(`/api/pre-trade-brief?status=${briefStatusFilter}`, { method: "GET" });
       if (!response.ok) {
         const payload = await response.json();
         throw new Error(payload.error || "Failed to load pre-trade brief data");
@@ -107,7 +120,12 @@ function PreTradeBriefContent() {
         setPairSymbol(nextPairs[0].symbol);
       }
 
-      if (!selectedBriefId && nextBriefs.length) {
+      if (selectedBriefId && !nextBriefs.some((brief) => brief.id === selectedBriefId)) {
+        setSelectedBriefId(nextBriefs[0]?.id ?? null);
+        if (!nextBriefs.length) {
+          setSelectedBrief(null);
+        }
+      } else if (!selectedBriefId && nextBriefs.length) {
         setSelectedBriefId(nextBriefs[0].id);
       }
     } catch (err) {
@@ -118,6 +136,17 @@ function PreTradeBriefContent() {
   };
 
   const loadBriefDetail = async (briefId: string) => {
+    const cachedDetail = detailCacheRef.current[briefId];
+    if (cachedDetail) {
+      setSelectedBrief(cachedDetail);
+      setTraderNotesDraft(cachedDetail.trader_notes || "");
+      setStatusDraft(
+        cachedDetail.status === "generated" || cachedDetail.status === "failed" ? "draft" : cachedDetail.status
+      );
+      setChecklistStateDraft(cachedDetail.checklist_state || {});
+      return;
+    }
+
     setDetailLoading(true);
     setDetailError(null);
 
@@ -129,6 +158,7 @@ function PreTradeBriefContent() {
       }
 
       const detail: PreTradeBriefRecord = await response.json();
+      detailCacheRef.current[briefId] = detail;
       setSelectedBrief(detail);
       setTraderNotesDraft(detail.trader_notes || "");
       setStatusDraft(
@@ -147,13 +177,19 @@ function PreTradeBriefContent() {
     if (status === "authenticated") {
       void loadData();
     }
-  }, [status]);
+  }, [status, briefStatusFilter]);
 
   useEffect(() => {
     if (status === "authenticated" && selectedBriefId) {
       void loadBriefDetail(selectedBriefId);
     }
   }, [status, selectedBriefId]);
+
+  useEffect(() => {
+    if (status === "authenticated" && pairSymbol) {
+      void loadLatestBias();
+    }
+  }, [status, pairSymbol]);
 
   if (status === "loading" || loading) {
     return (
@@ -241,22 +277,82 @@ function PreTradeBriefContent() {
       }
 
       const updated: PreTradeBriefRecord = await response.json();
+      detailCacheRef.current[selectedBriefId] = updated;
       setSelectedBrief((prev) => ({ ...(prev || {}), ...updated } as PreTradeBriefRecord));
 
       setRecentBriefs((prev) =>
-        prev.map((brief) =>
-          brief.id === updated.id
-            ? {
-                ...brief,
-                status: updated.status,
-              }
-            : brief
-        )
+        prev
+          .map((brief) =>
+            brief.id === updated.id
+              ? {
+                  ...brief,
+                  status: updated.status,
+                }
+              : brief
+          )
+          .filter((brief) => briefStatusFilter === "all" || brief.status === briefStatusFilter)
       );
     } catch (err) {
       setDetailError(err instanceof Error ? err.message : "Failed to save brief detail");
     } finally {
       setSavingDetail(false);
+    }
+  };
+
+  const toggleBiasTimeframe = (tf: string) => {
+    setBiasTimeframes((prev) => {
+      if (prev.includes(tf)) {
+        const next = prev.filter((item) => item !== tf);
+        return next.length ? next : prev;
+      }
+      return [...prev, tf];
+    });
+  };
+
+  const loadLatestBias = async () => {
+    setBiasError(null);
+    try {
+      const response = await fetch(`/api/market-bias?pairSymbol=${pairSymbol}`);
+      if (!response.ok) {
+        const payload = await response.json();
+        throw new Error(payload.error || "Failed to load market bias");
+      }
+      const payload = await response.json();
+      const reports = (payload.reports || []) as MarketBiasRecord[];
+      setLatestBias(reports[0] || null);
+    } catch (err) {
+      setBiasError(err instanceof Error ? err.message : "Failed to load market bias");
+      setLatestBias(null);
+    }
+  };
+
+  const handleGenerateBias = async () => {
+    setBiasError(null);
+    setGeneratingBias(true);
+
+    try {
+      const response = await fetch("/api/market-bias", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pairSymbol,
+          timeframeSet: biasTimeframes,
+          sessionContext: biasSessionContext,
+          recentBackdrop: biasBackdrop,
+        }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json();
+        throw new Error(payload.error || "Failed to generate market bias");
+      }
+
+      const created = (await response.json()) as MarketBiasRecord;
+      setLatestBias(created);
+    } catch (err) {
+      setBiasError(err instanceof Error ? err.message : "Failed to generate market bias");
+    } finally {
+      setGeneratingBias(false);
     }
   };
 
@@ -438,9 +534,130 @@ function PreTradeBriefContent() {
               </section>
             </div>
 
+            <div className="mt-6 grid gap-6 lg:grid-cols-2">
+              <section className="bg-white dark:bg-[#161B22] border border-gray-200 dark:border-gray-800 rounded-xl p-5">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Market Bias Snapshot</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                  Generate directional context before execution. This is decision-support only.
+                </p>
+
+                <div className="space-y-4">
+                  <div>
+                    <p className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Timeframes</p>
+                    <div className="flex flex-wrap gap-2">
+                      {BIAS_TIMEFRAMES.map((tf) => {
+                        const active = biasTimeframes.includes(tf);
+                        return (
+                          <button
+                            key={tf}
+                            type="button"
+                            onClick={() => toggleBiasTimeframe(tf)}
+                            className={`rounded-md border px-3 py-1 text-sm ${
+                              active
+                                ? "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300"
+                                : "border-gray-300 bg-white text-gray-700 dark:border-gray-700 dark:bg-[#0D1117] dark:text-gray-300"
+                            }`}
+                          >
+                            {tf}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+                      Session Context (optional)
+                    </label>
+                    <input
+                      value={biasSessionContext}
+                      onChange={(e) => setBiasSessionContext(e.target.value)}
+                      placeholder="Example: London open, moderate volatility"
+                      className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+                      Recent Backdrop (optional)
+                    </label>
+                    <textarea
+                      rows={3}
+                      value={biasBackdrop}
+                      onChange={(e) => setBiasBackdrop(e.target.value)}
+                      placeholder="Key events, recent structure, or volatility notes..."
+                      className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0D1117] px-3 py-2 text-sm"
+                    />
+                  </div>
+
+                  {biasError && (
+                    <div className="rounded-md border border-red-300 bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-700 dark:text-red-300">
+                      {biasError}
+                    </div>
+                  )}
+
+                  <Button type="button" onClick={handleGenerateBias} disabled={generatingBias || !pairSymbol}>
+                    {generatingBias ? "Generating Bias..." : `Generate Bias for ${pairSymbol}`}
+                  </Button>
+                </div>
+              </section>
+
+              <section className="bg-white dark:bg-[#161B22] border border-gray-200 dark:border-gray-800 rounded-xl p-5">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Latest Bias Result</h2>
+                {!latestBias ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    No saved bias report for {pairSymbol}. Generate a snapshot to begin.
+                  </p>
+                ) : (
+                  <div className="space-y-4">
+                    <div className="text-sm text-gray-700 dark:text-gray-300">
+                      <span className="font-medium">Direction:</span> {latestBias.bias_direction} |{" "}
+                      <span className="font-medium">Confidence:</span> {latestBias.confidence_score}
+                    </div>
+                    <div className="text-sm text-gray-700 dark:text-gray-300">
+                      <span className="font-medium">Timeframes:</span> {latestBias.timeframe_set.join(", ")}
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Assumptions</h3>
+                      {renderList(latestBias.assumptions || [])}
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Invalidation Conditions</h3>
+                      {renderList(latestBias.invalidation_conditions || [])}
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-white">Alternate Scenario</h3>
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">{latestBias.alternate_scenario || "N/A"}</p>
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      Generated: {formatDate(latestBias.created_at)}
+                    </div>
+                  </div>
+                )}
+              </section>
+            </div>
+
             <div className="mt-6 grid gap-6 lg:grid-cols-5">
               <section className="lg:col-span-2 bg-white dark:bg-[#161B22] border border-gray-200 dark:border-gray-800 rounded-xl p-5">
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Recent Saved Briefs</h2>
+                <div className="mb-4 flex items-end justify-between gap-3">
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Recent Saved Briefs</h2>
+                  <div>
+                    <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Status
+                    </label>
+                    <select
+                      value={briefStatusFilter}
+                      onChange={(e) => setBriefStatusFilter(e.target.value as BriefStatusFilter)}
+                      className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-[#0D1117]"
+                    >
+                      {BRIEF_STATUS_FILTERS.map((filterValue) => (
+                        <option key={filterValue} value={filterValue}>
+                          {filterValue}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
                 {!recentBriefs.length ? (
                   <p className="text-sm text-gray-500 dark:text-gray-400">No briefs saved yet.</p>
                 ) : (

--- a/database/migrations/002_create_user_feedback_table.sql
+++ b/database/migrations/002_create_user_feedback_table.sql
@@ -1,5 +1,5 @@
 -- Create the user_feedback table
-CREATE TABLE public.user_feedback (
+CREATE TABLE IF NOT EXISTS public.user_feedback (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   user_id uuid NOT NULL,
   focus text NULL,
@@ -14,15 +14,37 @@ CREATE TABLE public.user_feedback (
 ALTER TABLE public.user_feedback ENABLE ROW LEVEL SECURITY;
 
 -- Create a policy to allow users to insert their own feedback
-CREATE POLICY "Allow users to insert their own feedback"
-ON public.user_feedback
-FOR INSERT
-TO authenticated
-WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_feedback'
+      AND policyname = 'Allow users to insert their own feedback'
+  ) THEN
+    CREATE POLICY "Allow users to insert their own feedback"
+    ON public.user_feedback
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;
 
 -- Create a policy to allow users to view their own feedback
-CREATE POLICY "Allow users to view their own feedback"
-ON public.user_feedback
-FOR SELECT
-TO authenticated
-USING (auth.uid() = user_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_feedback'
+      AND policyname = 'Allow users to view their own feedback'
+  ) THEN
+    CREATE POLICY "Allow users to view their own feedback"
+    ON public.user_feedback
+    FOR SELECT
+    TO authenticated
+    USING (auth.uid() = user_id);
+  END IF;
+END $$;

--- a/database/migrations/003_fix_column_names.sql
+++ b/database/migrations/003_fix_column_names.sql
@@ -1,83 +1,34 @@
--- Fix Supabase schema cache issue with quoted column names
--- WARNING: This will drop and recreate the trades table with proper column names
--- BACKUP YOUR DATA BEFORE RUNNING THIS!
+-- Non-destructive compatibility fix for trades column naming and metadata.
+-- This migration intentionally avoids dropping/recreating public.trades.
 
--- Drop the existing table (dangerous - backup data first!)
-DROP TABLE IF EXISTS public.trades CASCADE;
+DO $$
+BEGIN
+  IF to_regclass('public.trades') IS NULL THEN
+    RAISE NOTICE 'public.trades does not exist; skipping 003_fix_column_names.sql';
+    RETURN;
+  END IF;
 
--- Recreate the table with proper unquoted column names for Supabase compatibility
-CREATE TABLE public.trades (
-  id uuid NOT NULL DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL,
-  symbol text NOT NULL,
-  direction text NULL,
-  ordertype text NULL,
-  opentime timestamptz NULL,
-  closetime timestamptz NULL,
-  session text NULL,
-  lotsize numeric NOT NULL DEFAULT 0.01,
-  entryprice numeric NOT NULL DEFAULT 0,
-  exitprice numeric NULL,
-  stoplossprice numeric NULL,
-  takeprofitprice numeric NULL,
-  pnl numeric NOT NULL DEFAULT 0,
-  profitloss text NULL,
-  resultrr numeric NULL,
-  rr text NULL,
-  outcome text NULL,
-  duration text NULL,
-  beforescreenshoturl text NULL,
-  afterscreenshoturl text NULL,
-  commission numeric NULL,
-  swap numeric NULL,
-  pinned boolean NULL DEFAULT false,
-  tags text[] NULL,
-  reviewed boolean NULL DEFAULT false,
-  strategy text NULL,
-  emotion text NULL,
-  reasonfortrade text NULL,
-  journalnotes text NULL,
-  notes text NULL,
-  raw jsonb NULL,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now(),
-  CONSTRAINT trades_pkey PRIMARY KEY (id)
-  -- Temporarily remove foreign key constraint to allow operations
-  -- CONSTRAINT trades_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE
-);
+  ALTER TABLE public.trades
+    ADD COLUMN IF NOT EXISTS ordertype text,
+    ADD COLUMN IF NOT EXISTS opentime timestamptz,
+    ADD COLUMN IF NOT EXISTS closetime timestamptz,
+    ADD COLUMN IF NOT EXISTS lotsize numeric DEFAULT 0.01,
+    ADD COLUMN IF NOT EXISTS entryprice numeric DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS exitprice numeric,
+    ADD COLUMN IF NOT EXISTS stoplossprice numeric,
+    ADD COLUMN IF NOT EXISTS takeprofitprice numeric,
+    ADD COLUMN IF NOT EXISTS profitloss text,
+    ADD COLUMN IF NOT EXISTS resultrr numeric,
+    ADD COLUMN IF NOT EXISTS rr text,
+    ADD COLUMN IF NOT EXISTS beforescreenshoturl text,
+    ADD COLUMN IF NOT EXISTS afterscreenshoturl text,
+    ADD COLUMN IF NOT EXISTS reasonfortrade text,
+    ADD COLUMN IF NOT EXISTS journalnotes text,
+    ADD COLUMN IF NOT EXISTS raw jsonb;
+END $$;
 
--- Temporarily disable RLS for testing (will enable proper policies after fixing the issue)
--- ALTER TABLE public.trades ENABLE ROW LEVEL SECURITY;
+CREATE INDEX IF NOT EXISTS trades_user_idx ON public.trades(user_id);
+CREATE INDEX IF NOT EXISTS trades_symbol_idx ON public.trades(symbol);
+CREATE INDEX IF NOT EXISTS trades_opentime_idx ON public.trades(opentime);
 
--- Drop existing policies and constraints if they exist
-DROP POLICY IF EXISTS "Allow all access for authenticated users" ON public.trades;
-DROP POLICY IF EXISTS "Allow inserts for authenticated users" ON public.trades;
-DROP POLICY IF EXISTS "Allow all operations for authenticated users" ON public.trades;
-DROP CONSTRAINT IF EXISTS trades_user_id_fkey ON public.trades;
-
--- For now, disable RLS to allow operations
-ALTER TABLE public.trades DISABLE ROW LEVEL SECURITY;
-
--- Create indexes for better performance
-CREATE INDEX IF NOT EXISTS trades_user_idx ON trades(user_id);
-CREATE INDEX IF NOT EXISTS trades_symbol_idx ON trades(symbol);
-CREATE INDEX IF NOT EXISTS trades_opentime_idx ON trades(opentime);
-
--- Add comments for documentation
 COMMENT ON TABLE public.trades IS 'Trading journal entries with complete trade data';
-COMMENT ON COLUMN public.trades.ordertype IS 'Type of order (Market Execution, Limit, etc.)';
-COMMENT ON COLUMN public.trades.opentime IS 'Time when the trade was opened';
-COMMENT ON COLUMN public.trades.closetime IS 'Time when the trade was closed';
-COMMENT ON COLUMN public.trades.lotsize IS 'Size of the trade in lots';
-COMMENT ON COLUMN public.trades.entryprice IS 'Price at which the trade was entered';
-COMMENT ON COLUMN public.trades.exitprice IS 'Price at which the trade was exited';
-COMMENT ON COLUMN public.trades.stoplossprice IS 'Stop loss price level';
-COMMENT ON COLUMN public.trades.takeprofitprice IS 'Take profit price level';
-COMMENT ON COLUMN public.trades.resultrr IS 'Result risk-reward ratio achieved';
-COMMENT ON COLUMN public.trades.beforescreenshoturl IS 'Screenshot URL before trade execution';
-COMMENT ON COLUMN public.trades.afterscreenshoturl IS 'Screenshot URL after trade execution';
-COMMENT ON COLUMN public.trades.strategy IS 'Trading strategy used for the trade';
-COMMENT ON COLUMN public.trades.emotion IS 'Emotional state during the trade';
-COMMENT ON COLUMN public.trades.reasonfortrade IS 'Reason for entering the trade';
-COMMENT ON COLUMN public.trades.journalnotes IS 'Detailed journal notes for the trade';
-COMMENT ON COLUMN public.trades.notes IS 'Additional notes for the trade';

--- a/database/migrations/004_enable_rls.sql
+++ b/database/migrations/004_enable_rls.sql
@@ -5,6 +5,7 @@
 ALTER TABLE public.trades ENABLE ROW LEVEL SECURITY;
 
 -- Create policy for authenticated users to access only their own trades
+DROP POLICY IF EXISTS "Users can access their own trades" ON public.trades;
 CREATE POLICY "Users can access their own trades"
 ON public.trades
 FOR ALL
@@ -14,6 +15,7 @@ WITH CHECK (auth.uid()::text = user_id::text);
 
 -- Add service role policy for backend operations (if needed)
 -- This allows the service role to bypass RLS for admin operations
+DROP POLICY IF EXISTS "Service role can access all trades" ON public.trades;
 CREATE POLICY "Service role can access all trades"
 ON public.trades
 FOR ALL

--- a/database/migrations/005_fix_foreign_key.sql
+++ b/database/migrations/005_fix_foreign_key.sql
@@ -1,17 +1,25 @@
 -- Fix foreign key constraint to reference auth.users table properly
 -- This ensures user_id in trades table matches the Supabase auth user ID
 
+DO $$
+BEGIN
+  IF to_regclass('public.trades') IS NULL THEN
+    RAISE NOTICE 'public.trades missing, skipping 005_fix_foreign_key.sql';
+    RETURN;
+  END IF;
+END $$;
+
 -- Drop the constraint if it exists (to avoid the "already exists" error)
 ALTER TABLE public.trades DROP CONSTRAINT IF EXISTS trades_user_id_fkey;
-
--- Add the foreign key constraint (it should work now that we're using correct user IDs)
-ALTER TABLE public.trades
-ADD CONSTRAINT trades_user_id_fkey
-FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 -- Clean up any orphaned records that might violate the constraint
 DELETE FROM public.trades
 WHERE user_id NOT IN (SELECT id FROM auth.users);
+
+-- Add the foreign key constraint after cleanup
+ALTER TABLE public.trades
+ADD CONSTRAINT trades_user_id_fkey
+FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 -- Optional: Add an index on user_id for better performance
 CREATE INDEX IF NOT EXISTS trades_user_id_idx ON public.trades(user_id);

--- a/database/migrations/006_fix_rls.sql
+++ b/database/migrations/006_fix_rls.sql
@@ -2,6 +2,14 @@
 -- This ensures authenticated users can perform all operations on their own trades
 
 -- First, ensure RLS is enabled
+DO $$
+BEGIN
+  IF to_regclass('public.trades') IS NULL THEN
+    RAISE NOTICE 'public.trades missing, skipping 006_fix_rls.sql';
+    RETURN;
+  END IF;
+END $$;
+
 ALTER TABLE public.trades ENABLE ROW LEVEL SECURITY;
 
 -- Drop any existing policies that might be causing issues

--- a/database/migrations/007_complete_setup.sql
+++ b/database/migrations/007_complete_setup.sql
@@ -1,89 +1,58 @@
--- COMPLETE TRADES SYSTEM SETUP
--- This migration sets up everything needed for the trading system to work
+-- COMPLETE TRADES SYSTEM SETUP (non-destructive replay-safe variant)
+-- This migration keeps existing data and only ensures expected columns, indexes, comments, and policy exist.
 
--- Step 1: Recreate trades table with all columns and proper setup
-DROP TABLE IF EXISTS public.trades CASCADE;
+DO $$
+BEGIN
+  IF to_regclass('public.trades') IS NULL THEN
+    RAISE NOTICE 'public.trades missing, skipping 007_complete_setup.sql';
+    RETURN;
+  END IF;
 
-CREATE TABLE public.trades (
-  id uuid NOT NULL DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL,
-  symbol text NOT NULL,
-  direction text NULL,
-  ordertype text NULL,
-  opentime timestamptz NULL,
-  closetime timestamptz NULL,
-  session text NULL,
-  lotsize numeric NOT NULL DEFAULT 0.01,
-  entryprice numeric NOT NULL DEFAULT 0,
-  exitprice numeric NULL,
-  stoplossprice numeric NULL,
-  takeprofitprice numeric NULL,
-  pnl numeric NOT NULL DEFAULT 0,
-  profitloss text NULL,
-  resultrr numeric NULL,
-  rr text NULL,
-  outcome text NULL,
-  duration text NULL,
-  beforescreenshoturl text NULL,
-  afterscreenshoturl text NULL,
-  commission numeric NULL,
-  swap numeric NULL,
-  pinned boolean NULL DEFAULT false,
-  tags text[] NULL,
-  reviewed boolean NULL DEFAULT false,
-  strategy text NULL,
-  emotion text NULL,
-  reasonfortrade text NULL,
-  journalnotes text NULL,
-  notes text NULL,
-  raw jsonb NULL,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now(),
-  CONSTRAINT trades_pkey PRIMARY KEY (id)
-);
+  ALTER TABLE public.trades
+    ADD COLUMN IF NOT EXISTS direction text,
+    ADD COLUMN IF NOT EXISTS ordertype text,
+    ADD COLUMN IF NOT EXISTS opentime timestamptz,
+    ADD COLUMN IF NOT EXISTS closetime timestamptz,
+    ADD COLUMN IF NOT EXISTS session text,
+    ADD COLUMN IF NOT EXISTS lotsize numeric NOT NULL DEFAULT 0.01,
+    ADD COLUMN IF NOT EXISTS entryprice numeric NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS exitprice numeric,
+    ADD COLUMN IF NOT EXISTS stoplossprice numeric,
+    ADD COLUMN IF NOT EXISTS takeprofitprice numeric,
+    ADD COLUMN IF NOT EXISTS pnl numeric NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS profitloss text,
+    ADD COLUMN IF NOT EXISTS resultrr numeric,
+    ADD COLUMN IF NOT EXISTS rr text,
+    ADD COLUMN IF NOT EXISTS outcome text,
+    ADD COLUMN IF NOT EXISTS duration text,
+    ADD COLUMN IF NOT EXISTS beforescreenshoturl text,
+    ADD COLUMN IF NOT EXISTS afterscreenshoturl text,
+    ADD COLUMN IF NOT EXISTS commission numeric,
+    ADD COLUMN IF NOT EXISTS swap numeric,
+    ADD COLUMN IF NOT EXISTS pinned boolean DEFAULT false,
+    ADD COLUMN IF NOT EXISTS tags text[],
+    ADD COLUMN IF NOT EXISTS reviewed boolean DEFAULT false,
+    ADD COLUMN IF NOT EXISTS strategy text,
+    ADD COLUMN IF NOT EXISTS emotion text,
+    ADD COLUMN IF NOT EXISTS reasonfortrade text,
+    ADD COLUMN IF NOT EXISTS journalnotes text,
+    ADD COLUMN IF NOT EXISTS notes text,
+    ADD COLUMN IF NOT EXISTS raw jsonb,
+    ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+END $$;
 
--- Step 2: Create indexes for performance
 CREATE INDEX IF NOT EXISTS trades_user_idx ON trades(user_id);
 CREATE INDEX IF NOT EXISTS trades_symbol_idx ON trades(symbol);
 CREATE INDEX IF NOT EXISTS trades_opentime_idx ON trades(opentime);
 
--- Step 3: Add comments for documentation
 COMMENT ON TABLE public.trades IS 'Trading journal entries with complete trade data';
-COMMENT ON COLUMN public.trades.ordertype IS 'Type of order (Market Execution, Limit, etc.)';
-COMMENT ON COLUMN public.trades.opentime IS 'Time when the trade was opened';
-COMMENT ON COLUMN public.trades.closetime IS 'Time when the trade was closed';
-COMMENT ON COLUMN public.trades.takeprofitprice IS 'Take profit price level';
-COMMENT ON COLUMN public.trades.resultrr IS 'Result risk-reward ratio achieved';
-COMMENT ON COLUMN public.trades.beforescreenshoturl IS 'Screenshot URL before trade execution';
-COMMENT ON COLUMN public.trades.afterscreenshoturl IS 'Screenshot URL after trade execution';
-COMMENT ON COLUMN public.trades.strategy IS 'Trading strategy used';
-COMMENT ON COLUMN public.trades.emotion IS 'Emotional state during trade';
-COMMENT ON COLUMN public.trades.reasonfortrade IS 'Reason for entering trade';
-COMMENT ON COLUMN public.trades.journalnotes IS 'Detailed journal notes';
-COMMENT ON COLUMN public.trades.notes IS 'Additional notes';
 
--- Step 4: Enable RLS and create policies
 ALTER TABLE public.trades ENABLE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS "authenticated_users_full_access" ON public.trades;
-
 CREATE POLICY "authenticated_users_full_access"
 ON public.trades
 FOR ALL
 TO authenticated
 USING (auth.uid()::text = user_id::text)
 WITH CHECK (auth.uid()::text = user_id::text);
-
--- Step 5: Test the setup by inserting a sample trade
--- (This will be removed after testing)
--- INSERT INTO public.trades (user_id, symbol, direction, lotsize, entryprice, pnl, outcome)
--- SELECT
---   auth.uid(),
---   'TEST_SYMBOL',
---   'Buy',
---   0.01,
---   100.0,
---   10.0,
---   'Win'
--- WHERE auth.uid() IS NOT NULL
--- LIMIT 1;

--- a/database/migrations/008_final_rls_fix.sql
+++ b/database/migrations/008_final_rls_fix.sql
@@ -1,6 +1,14 @@
 -- FINAL RLS FIX: Completely disable RLS for trades table to allow operations
 -- This will allow all authenticated operations while we debug the policy
 
+DO $$
+BEGIN
+  IF to_regclass('public.trades') IS NULL THEN
+    RAISE NOTICE 'public.trades missing, skipping 008_final_rls_fix.sql';
+    RETURN;
+  END IF;
+END $$;
+
 ALTER TABLE public.trades DISABLE ROW LEVEL SECURITY;
 
 -- Drop any existing policies that might be interfering

--- a/database/migrations/2025-01-15_add_lemonsqueezy_support.sql
+++ b/database/migrations/2025-01-15_add_lemonsqueezy_support.sql
@@ -58,14 +58,14 @@ BEGIN
 END $$;
 
 -- 3. Create indexes for faster lookups
-CREATE INDEX IF NOT EXISTS idx_user_plans_lemonsqueezy_order_id 
-  ON user_plans(lemonsqueezy_order_id);
-
-CREATE INDEX IF NOT EXISTS idx_user_plans_lemonsqueezy_subscription_id 
-  ON user_plans(lemonsqueezy_subscription_id);
-
-CREATE INDEX IF NOT EXISTS idx_user_plans_checkout_id 
-  ON user_plans(checkout_id);
+DO $$
+BEGIN
+  IF to_regclass('public.user_plans') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_user_plans_lemonsqueezy_order_id ON user_plans(lemonsqueezy_order_id);
+    CREATE INDEX IF NOT EXISTS idx_user_plans_lemonsqueezy_subscription_id ON user_plans(lemonsqueezy_subscription_id);
+    CREATE INDEX IF NOT EXISTS idx_user_plans_checkout_id ON user_plans(checkout_id);
+  END IF;
+END $$;
 
 -- 4. Create indexes on lemonsqueezy_products
 CREATE INDEX IF NOT EXISTS idx_lemonsqueezy_products_plan_key 
@@ -76,4 +76,9 @@ CREATE INDEX IF NOT EXISTS idx_lemonsqueezy_products_variant_id
 
 -- 5. Add comment for documentation
 COMMENT ON TABLE lemonsqueezy_products IS 'Stores mapping of plan keys to LemonSqueezy variant IDs for checkout processing';
-COMMENT ON TABLE user_plans IS 'User subscription and billing plan records, supports both legacy Flutterwave and LemonSqueezy payments';
+DO $$
+BEGIN
+  IF to_regclass('public.user_plans') IS NOT NULL THEN
+    COMMENT ON TABLE user_plans IS 'User subscription and billing plan records, supports both legacy Flutterwave and LemonSqueezy payments';
+  END IF;
+END $$;

--- a/database/migrations/2026-04-09_add_pre_trade_brief_review_fields.sql
+++ b/database/migrations/2026-04-09_add_pre_trade_brief_review_fields.sql
@@ -1,13 +1,28 @@
 -- Add review/edit support fields for pre_trade_briefs
-ALTER TABLE pre_trade_briefs
-  ADD COLUMN IF NOT EXISTS trader_notes TEXT,
-  ADD COLUMN IF NOT EXISTS checklist_state JSONB,
-  ADD COLUMN IF NOT EXISTS last_reviewed_at TIMESTAMPTZ;
+DO $$
+BEGIN
+  IF to_regclass('public.pre_trade_briefs') IS NULL THEN
+    RAISE NOTICE 'pre_trade_briefs missing, skipping add review fields migration';
+    RETURN;
+  END IF;
+
+  ALTER TABLE pre_trade_briefs
+    ADD COLUMN IF NOT EXISTS trader_notes TEXT,
+    ADD COLUMN IF NOT EXISTS checklist_state JSONB,
+    ADD COLUMN IF NOT EXISTS last_reviewed_at TIMESTAMPTZ;
+END $$;
 
 -- Expand status values for light workflow updates
-ALTER TABLE pre_trade_briefs
-  DROP CONSTRAINT IF EXISTS pre_trade_briefs_status_check;
+DO $$
+BEGIN
+  IF to_regclass('public.pre_trade_briefs') IS NULL THEN
+    RETURN;
+  END IF;
 
-ALTER TABLE pre_trade_briefs
-  ADD CONSTRAINT pre_trade_briefs_status_check
-  CHECK (status IN ('generated', 'draft', 'ready', 'invalidated', 'executed', 'skipped', 'failed'));
+  ALTER TABLE pre_trade_briefs
+    DROP CONSTRAINT IF EXISTS pre_trade_briefs_status_check;
+
+  ALTER TABLE pre_trade_briefs
+    ADD CONSTRAINT pre_trade_briefs_status_check
+    CHECK (status IN ('generated', 'draft', 'ready', 'invalidated', 'executed', 'skipped', 'failed'));
+END $$;

--- a/database/migrations/2026-04-18_create_market_bias_reports.sql
+++ b/database/migrations/2026-04-18_create_market_bias_reports.sql
@@ -1,0 +1,70 @@
+-- Create market bias reports table for phase-3 dashboard workflow integration
+CREATE TABLE IF NOT EXISTS market_bias_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  forex_pair_id UUID NOT NULL REFERENCES forex_pairs(id) ON DELETE RESTRICT,
+  pair_symbol_snapshot TEXT NOT NULL,
+  timeframe_set TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  bias_direction TEXT NOT NULL,
+  confidence_score NUMERIC NOT NULL,
+  key_levels JSONB NOT NULL DEFAULT '{}'::JSONB,
+  assumptions TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  invalidation_conditions TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  alternate_scenario TEXT,
+  confidence_rationale TEXT,
+  source TEXT NOT NULL DEFAULT 'ai',
+  raw_ai_response JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT market_bias_reports_bias_direction_check CHECK (bias_direction IN ('bullish', 'bearish', 'neutral')),
+  CONSTRAINT market_bias_reports_source_check CHECK (source IN ('manual', 'ai', 'hybrid')),
+  CONSTRAINT market_bias_reports_confidence_score_check CHECK (confidence_score >= 0 AND confidence_score <= 100)
+);
+
+CREATE INDEX IF NOT EXISTS idx_market_bias_reports_user_created ON market_bias_reports(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_market_bias_reports_pair ON market_bias_reports(forex_pair_id);
+
+CREATE OR REPLACE FUNCTION trg_market_bias_reports_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_market_bias_reports_updated_at ON market_bias_reports;
+CREATE TRIGGER trigger_market_bias_reports_updated_at
+  BEFORE UPDATE ON market_bias_reports
+  FOR EACH ROW
+  EXECUTE FUNCTION trg_market_bias_reports_updated_at();
+
+ALTER TABLE market_bias_reports ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS market_bias_reports_select_own ON market_bias_reports;
+CREATE POLICY market_bias_reports_select_own
+ON market_bias_reports
+FOR SELECT
+TO authenticated
+USING (auth.uid()::text = user_id::text);
+
+DROP POLICY IF EXISTS market_bias_reports_insert_own ON market_bias_reports;
+CREATE POLICY market_bias_reports_insert_own
+ON market_bias_reports
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid()::text = user_id::text);
+
+DROP POLICY IF EXISTS market_bias_reports_update_own ON market_bias_reports;
+CREATE POLICY market_bias_reports_update_own
+ON market_bias_reports
+FOR UPDATE
+TO authenticated
+USING (auth.uid()::text = user_id::text)
+WITH CHECK (auth.uid()::text = user_id::text);
+
+DROP POLICY IF EXISTS market_bias_reports_delete_own ON market_bias_reports;
+CREATE POLICY market_bias_reports_delete_own
+ON market_bias_reports
+FOR DELETE
+TO authenticated
+USING (auth.uid()::text = user_id::text);

--- a/database/migrations/create_trading_accounts.sql
+++ b/database/migrations/create_trading_accounts.sql
@@ -28,6 +28,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trg_trading_accounts_updated ON trading_accounts;
 CREATE TRIGGER trg_trading_accounts_updated
   BEFORE UPDATE ON trading_accounts
   FOR EACH ROW

--- a/database/migrations/create_user_profiles.sql
+++ b/database/migrations/create_user_profiles.sql
@@ -25,25 +25,32 @@ ON CONFLICT (id) DO NOTHING;
 ALTER TABLE user_profiles ENABLE ROW LEVEL SECURITY;
 
 -- Policy: Users can only see and modify their own profiles
+DROP POLICY IF EXISTS "Users can view own profile" ON user_profiles;
 CREATE POLICY "Users can view own profile" ON user_profiles
   FOR SELECT USING (auth.jwt() ->> 'email' = email);
 
+DROP POLICY IF EXISTS "Users can update own profile" ON user_profiles;
 CREATE POLICY "Users can update own profile" ON user_profiles
   FOR UPDATE USING (auth.jwt() ->> 'email' = email);
 
+DROP POLICY IF EXISTS "Users can insert own profile" ON user_profiles;
 CREATE POLICY "Users can insert own profile" ON user_profiles
   FOR INSERT WITH CHECK (auth.jwt() ->> 'email' = email);
 
 -- Storage policy for user uploads
+DROP POLICY IF EXISTS "Users can upload their own files" ON storage.objects;
 CREATE POLICY "Users can upload their own files" ON storage.objects
   FOR INSERT WITH CHECK (bucket_id = 'user-uploads' AND auth.uid()::text = (storage.foldername(name))[1]);
 
+DROP POLICY IF EXISTS "Users can view their own files" ON storage.objects;
 CREATE POLICY "Users can view their own files" ON storage.objects
   FOR SELECT USING (bucket_id = 'user-uploads' AND auth.uid()::text = (storage.foldername(name))[1]);
 
+DROP POLICY IF EXISTS "Users can update their own files" ON storage.objects;
 CREATE POLICY "Users can update their own files" ON storage.objects
   FOR UPDATE USING (bucket_id = 'user-uploads' AND auth.uid()::text = (storage.foldername(name))[1]);
 
+DROP POLICY IF EXISTS "Users can delete their own files" ON storage.objects;
 CREATE POLICY "Users can delete their own files" ON storage.objects
   FOR DELETE USING (bucket_id = 'user-uploads' AND auth.uid()::text = (storage.foldername(name))[1]);
 
@@ -57,6 +64,7 @@ END;
 $$ language 'plpgsql';
 
 -- Trigger to automatically update updated_at
+DROP TRIGGER IF EXISTS update_user_profiles_updated_at ON user_profiles;
 CREATE TRIGGER update_user_profiles_updated_at
   BEFORE UPDATE ON user_profiles
   FOR EACH ROW

--- a/database/migrations/enhance_trading_accounts.sql
+++ b/database/migrations/enhance_trading_accounts.sql
@@ -7,6 +7,9 @@ ADD COLUMN IF NOT EXISTS account_size NUMERIC(14,2) DEFAULT 0;
 
 -- Add a constraint to ensure account_size is not negative
 ALTER TABLE trading_accounts
+DROP CONSTRAINT IF EXISTS check_account_size_positive;
+
+ALTER TABLE trading_accounts
 ADD CONSTRAINT check_account_size_positive CHECK (account_size >= 0);
 
 -- Create an index on user_id and is_active for faster queries

--- a/database/migrations/seed_sample_analytics.sql
+++ b/database/migrations/seed_sample_analytics.sql
@@ -5,32 +5,91 @@
 DO $$
 DECLARE
   v_user UUID;
+  has_source BOOLEAN;
+  has_open_time BOOLEAN;
+  has_close_time BOOLEAN;
+  has_reason_for_trade BOOLEAN;
+  has_journal_notes BOOLEAN;
 BEGIN
-  SELECT id INTO v_user FROM users ORDER BY created_at DESC NULLS LAST LIMIT 1;
+  SELECT u.id
+  INTO v_user
+  FROM users u
+  WHERE EXISTS (SELECT 1 FROM auth.users au WHERE au.id = u.id)
+  ORDER BY u.created_at DESC NULLS LAST
+  LIMIT 1;
+
   IF v_user IS NULL THEN
-    RAISE NOTICE 'No users found; skipping seed.';
+    SELECT au.id
+    INTO v_user
+    FROM auth.users au
+    WHERE EXISTS (SELECT 1 FROM users u WHERE u.id = au.id)
+    ORDER BY au.created_at DESC NULLS LAST
+    LIMIT 1;
+  END IF;
+
+  IF v_user IS NULL THEN
+    RAISE NOTICE 'No shared users/auth.users id found; skipping seed.';
     RETURN;
   END IF;
 
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'trades' AND column_name = 'source'
+  ) INTO has_source;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'trades' AND column_name = 'open_time'
+  ) INTO has_open_time;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'trades' AND column_name = 'close_time'
+  ) INTO has_close_time;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'trades' AND column_name = 'reasonfortrade'
+  ) INTO has_reason_for_trade;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'trades' AND column_name = 'journalnotes'
+  ) INTO has_journal_notes;
+
   -- Insert a handful of trades across different times and outcomes
-  INSERT INTO trades(user_id, symbol, outcome, pnl, source, open_time, close_time, deal_id, strategy, reasonForTrade, emotion, journalNotes)
-  VALUES
-    (v_user, 'EURUSD', 'Win', 120.50, 'manual', NOW() - INTERVAL '10 days', NOW() - INTERVAL '10 days' + INTERVAL '2 hours', NULL, 'Breakout', 'Momentum entry', 'confident', 'Good timing on breakout'),
-    (v_user, 'GBPUSD', 'Loss', -75.25, 'manual', NOW() - INTERVAL '8 days', NOW() - INTERVAL '8 days' + INTERVAL '1 hour', NULL, 'Pullback', 'Late entry', 'frustrated', 'Chased pullback late'),
-    (v_user, 'XAUUSD', 'Win', 245.10, 'import', NOW() - INTERVAL '6 days', NOW() - INTERVAL '6 days' + INTERVAL '3 hours', 'MT5-12345', 'Trend', 'Higher timeframe confluence', 'focused', 'Strong trend continuation'),
-    (v_user, 'BTCUSD', 'Loss', -130.00, 'mt5', NOW() - INTERVAL '3 days', NOW() - INTERVAL '3 days' + INTERVAL '45 minutes', 'MT5-67890', 'Counter-trend', 'Overextended move', 'anxious', 'Counter-trend too early'),
-    (v_user, 'EURJPY', 'Win', 62.75, 'manual', NOW() - INTERVAL '1 days', NOW() - INTERVAL '1 days' + INTERVAL '30 minutes', NULL, 'Scalp', 'Session momentum', 'calm', 'Quick scalp in London');
+  IF has_source AND has_open_time AND has_close_time AND has_reason_for_trade AND has_journal_notes THEN
+    INSERT INTO trades(user_id, symbol, outcome, pnl, source, open_time, close_time, deal_id, strategy, reasonForTrade, emotion, journalNotes)
+    VALUES
+      (v_user, 'EURUSD', 'Win', 120.50, 'manual', NOW() - INTERVAL '10 days', NOW() - INTERVAL '10 days' + INTERVAL '2 hours', NULL, 'Breakout', 'Momentum entry', 'confident', 'Good timing on breakout'),
+      (v_user, 'GBPUSD', 'Loss', -75.25, 'manual', NOW() - INTERVAL '8 days', NOW() - INTERVAL '8 days' + INTERVAL '1 hour', NULL, 'Pullback', 'Late entry', 'frustrated', 'Chased pullback late'),
+      (v_user, 'XAUUSD', 'Win', 245.10, 'import', NOW() - INTERVAL '6 days', NOW() - INTERVAL '6 days' + INTERVAL '3 hours', 'MT5-12345', 'Trend', 'Higher timeframe confluence', 'focused', 'Strong trend continuation'),
+      (v_user, 'BTCUSD', 'Loss', -130.00, 'mt5', NOW() - INTERVAL '3 days', NOW() - INTERVAL '3 days' + INTERVAL '45 minutes', 'MT5-67890', 'Counter-trend', 'Overextended move', 'anxious', 'Counter-trend too early'),
+      (v_user, 'EURJPY', 'Win', 62.75, 'manual', NOW() - INTERVAL '1 days', NOW() - INTERVAL '1 days' + INTERVAL '30 minutes', NULL, 'Scalp', 'Session momentum', 'calm', 'Quick scalp in London');
+  ELSE
+    INSERT INTO trades(user_id, symbol, outcome, pnl, strategy, emotion, notes)
+    VALUES
+      (v_user, 'EURUSD', 'Win', 120.50, 'Breakout', 'confident', 'Good timing on breakout'),
+      (v_user, 'GBPUSD', 'Loss', -75.25, 'Pullback', 'frustrated', 'Chased pullback late'),
+      (v_user, 'XAUUSD', 'Win', 245.10, 'Trend', 'focused', 'Strong trend continuation'),
+      (v_user, 'BTCUSD', 'Loss', -130.00, 'Counter-trend', 'anxious', 'Counter-trend too early'),
+      (v_user, 'EURJPY', 'Win', 62.75, 'Scalp', 'calm', 'Quick scalp in London');
+  END IF;
 
   -- Insert a couple of trade plans
-  INSERT INTO trade_plans(user_id, symbol, setup_type, planned_entry, stop_loss, take_profit, lot_size, risk_reward, notes, status)
-  VALUES
-    (v_user, 'EURUSD', 'Breakout', 1.0900, 1.0875, 1.0950, 1, 2.0, 'London breakout setup', 'planned'),
-    (v_user, 'XAUUSD', 'Pullback', 2350.00, 2340.00, 2375.00, 0.5, 2.5, 'H4 pullback into demand', 'planned');
+  IF to_regclass('public.trade_plans') IS NOT NULL THEN
+    INSERT INTO trade_plans(user_id, symbol, setup_type, planned_entry, stop_loss, take_profit, lot_size, risk_reward, notes, status)
+    VALUES
+      (v_user, 'EURUSD', 'Breakout', 1.0900, 1.0875, 1.0950, 1, 2.0, 'London breakout setup', 'planned'),
+      (v_user, 'XAUUSD', 'Pullback', 2350.00, 2340.00, 2375.00, 0.5, 2.5, 'H4 pullback into demand', 'planned');
+  END IF;
 
   -- Insert AI chat session summary rows
-  INSERT INTO ai_chat_sessions(user_id, started_at, ended_at, last_message_at, message_count, metadata)
-  VALUES
-    (v_user, NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days' + INTERVAL '10 minutes', NOW() - INTERVAL '2 days' + INTERVAL '10 minutes', 6, '{"topic":"performance"}'::jsonb),
-    (v_user, NOW() - INTERVAL '12 hours', NULL, NOW() - INTERVAL '11 hours', 3, '{"topic":"risk"}'::jsonb);
+  IF to_regclass('public.ai_chat_sessions') IS NOT NULL THEN
+    INSERT INTO ai_chat_sessions(user_id, started_at, ended_at, last_message_at, message_count, metadata)
+    VALUES
+      (v_user, NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days' + INTERVAL '10 minutes', NOW() - INTERVAL '2 days' + INTERVAL '10 minutes', 6, '{"topic":"performance"}'::jsonb),
+      (v_user, NOW() - INTERVAL '12 hours', NULL, NOW() - INTERVAL '11 hours', 3, '{"topic":"risk"}'::jsonb);
+  END IF;
 END $$;
 

--- a/migrations/002_remove_mt5_integration.sql
+++ b/migrations/002_remove_mt5_integration.sql
@@ -9,7 +9,12 @@ DROP TABLE IF EXISTS mt5_connection_monitoring CASCADE;
 DROP TABLE IF EXISTS mt5_security_audit CASCADE;
 
 -- Drop triggers (they depend on the tables)
-DROP TRIGGER IF EXISTS trigger_mt5_sync_sessions_updated_at ON mt5_sync_sessions;
+DO $$
+BEGIN
+  IF to_regclass('public.mt5_sync_sessions') IS NOT NULL THEN
+    DROP TRIGGER IF EXISTS trigger_mt5_sync_sessions_updated_at ON mt5_sync_sessions;
+  END IF;
+END $$;
 
 -- Drop functions
 DROP FUNCTION IF EXISTS update_mt5_sync_sessions_updated_at();

--- a/migrations/006_add_mt5_tables.sql
+++ b/migrations/006_add_mt5_tables.sql
@@ -37,6 +37,10 @@ CREATE TABLE IF NOT EXISTS public.trades (
     mt5_account_id UUID REFERENCES public.mt5_accounts(id)
 );
 
+-- Existing trades table may predate mt5_account_id; ensure column exists in that case.
+ALTER TABLE IF EXISTS public.trades
+ADD COLUMN IF NOT EXISTS mt5_account_id UUID REFERENCES public.mt5_accounts(id);
+
 -- Add index for faster lookups
 CREATE INDEX IF NOT EXISTS idx_mt5_accounts_user_id ON public.mt5_accounts(user_id);
 CREATE INDEX IF NOT EXISTS idx_trades_user_id ON public.trades(user_id);

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -7,6 +7,40 @@ import bcrypt from "bcryptjs";
 import { createAdminSupabase } from "@/utils/supabase/admin";
 import type { NextAuthOptions } from "next-auth";
 
+const DEFAULT_PROD_BASE_URL = "https://tradiaai.app";
+
+const sanitizeUrl = (raw?: string | null): string | null => {
+  if (!raw) return null;
+
+  const trimmed = raw.trim().replace(/^['"]+|['"]+$/g, "");
+  if (!trimmed) return null;
+
+  const repaired = trimmed.replace(/^([a-zA-Z][a-zA-Z0-9+\-.]*)"\/\//, "$1://");
+
+  try {
+    return new URL(repaired).origin;
+  } catch {
+    return null;
+  }
+};
+
+const resolveSafeBaseUrl = (baseUrl: string): string => {
+  const isProd = process.env.NODE_ENV === "production";
+  const candidates = [
+    sanitizeUrl(baseUrl),
+    sanitizeUrl(process.env.NEXTAUTH_URL),
+    sanitizeUrl(process.env.NEXT_PUBLIC_BASE_URL),
+  ].filter(Boolean) as string[];
+
+  const firstNonLocal = candidates.find((candidate) => !candidate.includes("localhost"));
+  if (isProd && firstNonLocal) return firstNonLocal;
+
+  const firstCandidate = candidates[0];
+  if (firstCandidate) return firstCandidate;
+
+  return isProd ? DEFAULT_PROD_BASE_URL : "http://localhost:3000";
+};
+
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
@@ -167,12 +201,15 @@ export const authOptions: NextAuthOptions = {
     },
 
     async redirect({ url, baseUrl }) {
+      const safeBaseUrl = resolveSafeBaseUrl(baseUrl);
+
       // Allows relative callback URLs
-      if (url.startsWith("/")) return `${baseUrl}${url}`;
+      if (url.startsWith("/")) return `${safeBaseUrl}${url}`;
       // Allows callback URLs on the same origin
-      else if (new URL(url).origin === baseUrl) return url;
+      const safeCallbackUrl = sanitizeUrl(url);
+      if (safeCallbackUrl && safeCallbackUrl === safeBaseUrl) return url;
       // Default redirect to dashboard after successful login
-      return `${baseUrl}/dashboard`;
+      return `${safeBaseUrl}/dashboard`;
     },
   },
 
@@ -182,4 +219,3 @@ export const authOptions: NextAuthOptions = {
   },
   secret: process.env.NEXTAUTH_SECRET,
 };
-

--- a/src/lib/forex/marketBiasService.ts
+++ b/src/lib/forex/marketBiasService.ts
@@ -1,0 +1,117 @@
+import { mistral } from "@ai-sdk/mistral";
+import { generateText } from "ai";
+import type { GeneratedMarketBias, MarketBiasInput } from "@/types/marketBias";
+
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+const toStringArray = (value: unknown, fallback: string[]): string[] => {
+  if (!Array.isArray(value)) return fallback;
+  const next = value
+    .map((item) => String(item ?? "").trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  return next.length ? next : fallback;
+};
+
+const toNumberArray = (value: unknown): number[] => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => Number(item))
+    .filter((item) => Number.isFinite(item))
+    .slice(0, 8);
+};
+
+const fallbackBias = (input: MarketBiasInput): GeneratedMarketBias => ({
+  biasDirection: "neutral",
+  confidenceScore: 50,
+  keyLevels: {
+    support: [],
+    resistance: [],
+    invalidationLevel: null,
+  },
+  assumptions: [
+    `${input.pairSymbol} is in a transitional structure with mixed signals across selected timeframes.`,
+    "Session behavior and volatility expansion should confirm direction before entry decisions.",
+  ],
+  invalidationConditions: [
+    "Directional thesis fails if market breaks structure against the intended scenario.",
+    "Volatility regime change invalidates planned execution conditions.",
+  ],
+  alternateScenario: "If the current structure fails, switch to scenario-based planning and wait for confirmation.",
+  confidenceRationale: "Confidence is moderate due to incomplete confluence and no guaranteed directional continuation.",
+});
+
+const parseDirection = (value: unknown): GeneratedMarketBias["biasDirection"] => {
+  const next = String(value ?? "").trim().toLowerCase();
+  if (next === "bullish" || next === "bearish" || next === "neutral") return next;
+  return "neutral";
+};
+
+const parseModelOutput = (raw: string, input: MarketBiasInput): GeneratedMarketBias => {
+  try {
+    const parsed = JSON.parse(raw);
+    const fallback = fallbackBias(input);
+    return {
+      biasDirection: parseDirection(parsed.biasDirection),
+      confidenceScore: clamp(Number(parsed.confidenceScore) || fallback.confidenceScore, 0, 100),
+      keyLevels: {
+        support: toNumberArray(parsed?.keyLevels?.support),
+        resistance: toNumberArray(parsed?.keyLevels?.resistance),
+        invalidationLevel: Number.isFinite(Number(parsed?.keyLevels?.invalidationLevel))
+          ? Number(parsed.keyLevels.invalidationLevel)
+          : null,
+      },
+      assumptions: toStringArray(parsed.assumptions, fallback.assumptions),
+      invalidationConditions: toStringArray(parsed.invalidationConditions, fallback.invalidationConditions),
+      alternateScenario: String(parsed.alternateScenario || fallback.alternateScenario).trim(),
+      confidenceRationale: String(parsed.confidenceRationale || fallback.confidenceRationale).trim(),
+    };
+  } catch {
+    return fallbackBias(input);
+  }
+};
+
+export async function generateMarketBias(input: MarketBiasInput): Promise<GeneratedMarketBias> {
+  const prompt = `You are Tradia's Forex market bias assistant.
+
+Return only valid JSON with this exact shape:
+{
+  "biasDirection": "bullish|bearish|neutral",
+  "confidenceScore": number_0_to_100,
+  "keyLevels": {
+    "support": [number],
+    "resistance": [number],
+    "invalidationLevel": number_or_null
+  },
+  "assumptions": ["string"],
+  "invalidationConditions": ["string"],
+  "alternateScenario": "string",
+  "confidenceRationale": "string"
+}
+
+Rules:
+- Decision-support only, no certainty language.
+- Do not give direct execution commands.
+- Include uncertainty where timeframes conflict.
+- Keep confidence conservative.
+
+Context:
+- Pair: ${input.pairSymbol}
+- Timeframes: ${input.timeframeSet.join(", ")}
+- Session context: ${input.sessionContext || "N/A"}
+- Recent backdrop: ${input.recentBackdrop || "N/A"}`;
+
+  try {
+    const result = await generateText({
+      model: mistral("mistral-large-latest") as any,
+      prompt,
+      temperature: 0.2,
+      maxTokens: 700,
+    });
+
+    return parseModelOutput(result.text, input);
+  } catch (error) {
+    console.error("Market bias AI generation failed:", error);
+    return fallbackBias(input);
+  }
+}

--- a/src/types/marketBias.ts
+++ b/src/types/marketBias.ts
@@ -1,0 +1,45 @@
+export type BiasDirection = "bullish" | "bearish" | "neutral";
+export type BiasSource = "manual" | "ai" | "hybrid";
+
+export interface MarketBiasInput {
+  pairSymbol: string;
+  timeframeSet: string[];
+  sessionContext?: string;
+  recentBackdrop?: string;
+}
+
+export interface GeneratedMarketBias {
+  biasDirection: BiasDirection;
+  confidenceScore: number;
+  keyLevels: {
+    support: number[];
+    resistance: number[];
+    invalidationLevel: number | null;
+  };
+  assumptions: string[];
+  invalidationConditions: string[];
+  alternateScenario: string;
+  confidenceRationale: string;
+}
+
+export interface MarketBiasRecord {
+  id: string;
+  user_id: string;
+  forex_pair_id: string;
+  pair_symbol_snapshot: string;
+  timeframe_set: string[];
+  bias_direction: BiasDirection;
+  confidence_score: number;
+  key_levels: {
+    support: number[];
+    resistance: number[];
+    invalidationLevel: number | null;
+  };
+  assumptions: string[];
+  invalidation_conditions: string[];
+  alternate_scenario: string | null;
+  confidence_rationale: string | null;
+  source: BiasSource;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
This PR fixes production Google OAuth callback host resolution and hardens SQL migration replay so remote Supabase execution can be re-run safely using CLI credentials from `.env.local`.

It also carries the phase-3 market bias slice that was implemented in the same working stream (API, service, types, migration, and dashboard integration).

## User-impacting fix: Google OAuth callback host
Users were still being redirected through `http://localhost:3000/api/auth/callback/google` during "Continue with Google" in environments where stale/malformed host env values leaked into runtime behavior.

### Root cause
- NextAuth route handling could still inherit host/base-url state that pointed at localhost.
- Existing fallback sanitation in `authOptions` handled malformed URL strings, but did not force request-derived host resolution at the API route boundary.

### Fix
- Updated `app/api/auth/[...nextauth]/route.ts` to derive and set `NEXTAUTH_URL` per request from `x-forwarded-host` / `host` and protocol headers.
- Added production safety fallback to `https://tradiaai.app` whenever request host is missing or localhost-like.
- Kept existing safe redirect normalization in `src/lib/authOptions.ts`.

This ensures callback URLs are generated from the actual deployed host in production, not localhost.

## SQL replay hardening and Supabase push work
The user requested pushing all SQL with `SUPABASE_ACCESS_TOKEN` + `SUPABASE_DB_PASSWORD` from `.env.local`.

### What was done
- Linked Supabase CLI project using those credentials.
- Executed migrations against linked remote DB via CLI.
- Iteratively patched failing scripts to be replay-safe/idempotent:
  - guarded duplicate policy/trigger/constraint creation
  - fixed constraint ordering for FK re-add
  - made seed migration resilient to schema/user-id mismatches
  - replaced destructive "drop/recreate trades" migration behavior with non-destructive compatibility updates
  - added missing-table guards in RLS/fix scripts
  - patched MT5 add/remove scripts for missing-object replay safety

### Representative files hardened
- `database/migrations/002_create_user_feedback_table.sql`
- `database/migrations/003_fix_column_names.sql`
- `database/migrations/004_enable_rls.sql`
- `database/migrations/005_fix_foreign_key.sql`
- `database/migrations/006_fix_rls.sql`
- `database/migrations/007_complete_setup.sql`
- `database/migrations/008_final_rls_fix.sql`
- `database/migrations/2025-01-15_add_lemonsqueezy_support.sql`
- `database/migrations/2026-04-09_add_pre_trade_brief_review_fields.sql`
- `database/migrations/create_trading_accounts.sql`
- `database/migrations/create_user_profiles.sql`
- `database/migrations/enhance_trading_accounts.sql`
- `database/migrations/seed_sample_analytics.sql`
- `migrations/002_remove_mt5_integration.sql`
- `migrations/006_add_mt5_tables.sql`

## Phase-3 market bias implementation included
- New migration:
  - `database/migrations/2026-04-18_create_market_bias_reports.sql`
- New API:
  - `app/api/market-bias/route.ts`
- New service and types:
  - `src/lib/forex/marketBiasService.ts`
  - `src/types/marketBias.ts`
- Dashboard integration:
  - `app/dashboard/pre-trade-brief/page.tsx`
- Pre-trade API/list filtering improvements:
  - `app/api/pre-trade-brief/route.ts`

## Validation
- `npm run type-check` passes.
- Supabase linked query path verified with `.env.local` credentials.
- Replay-safe migration execution improved substantially and blockers were patched directly in migration files.

## Notes
This PR intentionally keeps all fixes in one branch because the user requested the OAuth fix first, then phase continuation, plus SQL push hardening in the same workflow.
